### PR TITLE
fix: publishing pipeline has wrong names

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          packages=("packages/@autonomys/auto-utils")
+          packages=("packages/auto-utils", "packages/auto-id", "packages/auto-consensus", "packages/auto-xdm")
 
           for package in "${packages[@]}"; do
             echo "Publishing $package"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,5 +47,5 @@ jobs:
             echo "Publishing $package"
             cd $package
             npm publish --access public
-            cd ../..
+            cd -
           done


### PR DESCRIPTION
### **PR Type**
bug fix, configuration changes


___

### **Description**
- Fixed the publishing pipeline by correcting the package names.
- Updated the list of packages to include `auto-id`, `auto-consensus`, and `auto-xdm`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish.yaml</strong><dd><code>Fix and update package names in publishing pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish.yaml

<li>Updated the list of packages to be published.<br> <li> Added new packages: <code>auto-id</code>, <code>auto-consensus</code>, <code>auto-xdm</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/auto-sdk/pull/97/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

