### PR TITLE
Fixed missing folder name in metadata

### DIFF
--- a/packages/auto-drive/src/metadata/offchain/folder.ts
+++ b/packages/auto-drive/src/metadata/offchain/folder.ts
@@ -17,6 +17,7 @@ export type OffchainFolderMetadata = {
 export const folderMetadata = (
   cid: string,
   children: ChildrenMetadata[],
+  name?: string,
 ): OffchainFolderMetadata => {
   return {
     dataCid: cid,
@@ -24,5 +25,6 @@ export const folderMetadata = (
     totalFiles: children.length,
     children,
     type: 'folder',
+    name,
   }
 }


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed an issue where the folder name was missing in the `OffchainFolderMetadata` by adding an optional `name` parameter to the `folderMetadata` function.
- Updated the `folderMetadata` function to include the `name` in the returned metadata object.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>folder.ts</strong><dd><code>Add optional folder name to metadata function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auto-drive/src/metadata/offchain/folder.ts

<li>Added an optional <code>name</code> parameter to the <code>folderMetadata</code> function.<br> <li> Included <code>name</code> in the returned <code>OffchainFolderMetadata</code> object.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/auto-sdk/pull/107/files#diff-798d3ca5c83bb15d2128d0b3caa4306e8adc40fd097e57fd3f139d8c53001693">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

