### PR TITLE
Fix spacePledge return type

### DIFF
--- a/packages/auto-consensus/src/info.ts
+++ b/packages/auto-consensus/src/info.ts
@@ -44,7 +44,7 @@ export const solutionRanges = async (api: Api) => {
   }
 }
 
-export const shouldAdjustSolutionRange = async (api: Api) =>
+export const shouldAdjustSolutionRange = async (api: Api): Promise<boolean> =>
   await query<boolean>(api, 'subspace.shouldAdjustSolutionRange', [])
 
 export const segmentCommitment = async (api: Api) =>
@@ -53,7 +53,7 @@ export const segmentCommitment = async (api: Api) =>
 export const slotProbability = (api: Api): [number, number] =>
   api.consts.subspace.slotProbability.toPrimitive() as [number, number]
 
-export const maxPiecesInSector = (api: Api) =>
+export const maxPiecesInSector = (api: Api): bigint =>
   BigInt(api.consts.subspace.maxPiecesInSector.toPrimitive() as number)
 
 export function solutionRangeToSectors(
@@ -72,12 +72,12 @@ export function solutionRangeToSectors(
   return sectors / solutionRange
 }
 
-export const spacePledge = async (api: Api) => {
+export const spacePledge = async (api: Api): Promise<bigint> => {
   const _solutionRanges = await solutionRanges(api)
   const _slotProbability = slotProbability(api)
   const _maxPiecesInSector = maxPiecesInSector(api)
 
-  if (!_solutionRanges.current || !_slotProbability || !_maxPiecesInSector) return 0
+  if (!_solutionRanges.current || !_slotProbability || !_maxPiecesInSector) return BigInt(0)
 
   const sectors = solutionRangeToSectors(
     _solutionRanges.current,
@@ -89,7 +89,7 @@ export const spacePledge = async (api: Api) => {
   return totalSpacePledged
 }
 
-export const blockchainSize = async (api: Api) => {
+export const blockchainSize = async (api: Api): Promise<bigint> => {
   const _segmentCommitment = await segmentCommitment(api)
   const segmentsCount = BigInt(_segmentCommitment.length)
 


### PR DESCRIPTION
### **User description**
## Fix spacePledge return type

spacePledge was returning bigint | number, making it harder to use, now returning only bigint


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Changed the return type of the `spacePledge` function to `Promise<bigint>`, ensuring consistency and ease of use.
- Updated the `shouldAdjustSolutionRange` function to explicitly return a `Promise<boolean>`.
- Modified the `maxPiecesInSector` function to return a `bigint` instead of a number.
- Ensured the `blockchainSize` function returns a `Promise<bigint>`, aligning with the new standard.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>info.ts</strong><dd><code>Standardize return types for consistency and clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auto-consensus/src/info.ts

<li>Changed return type of <code>spacePledge</code> to <code>Promise<bigint></code>.<br> <li> Updated <code>shouldAdjustSolutionRange</code> to explicitly return <code>Promise<boolean></code>.<br> <li> Modified <code>maxPiecesInSector</code> to return <code>bigint</code>.<br> <li> Ensured <code>blockchainSize</code> returns <code>Promise<bigint></code>.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/auto-sdk/pull/120/files#diff-24b4a9c81e2e7a71bbcd34fde8eee2478d871e8d25cc658151079a091d4d582c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information