### PR TITLE
Fix spacePledge typo -> spacePledged

### DIFF
--- a/packages/auto-consensus/src/info.ts
+++ b/packages/auto-consensus/src/info.ts
@@ -94,7 +94,12 @@ export const spacePledged = async (api: Api): Promise<bigint> => {
 }
 
 // This function is deprecated (use spacePledged instead) and will be removed in a future major release
-export const spacePledge = async (api: Api): Promise<bigint> => spacePledged(api)
+export const spacePledge = async (api: Api): Promise<bigint> => {
+  console.warn(
+    'spacePledge is deprecated (use spacePledged instead) and will be removed in a future major release',
+  )
+  return spacePledged(api)
+}
 
 export const blockchainSize = async (api: Api): Promise<bigint> => {
   const _segmentCommitment = await segmentCommitment(api)

--- a/packages/auto-consensus/src/info.ts
+++ b/packages/auto-consensus/src/info.ts
@@ -78,7 +78,7 @@ export function solutionRangeToPieces(
   return pieces / solutionRange
 }
 
-export const spacePledge = async (api: Api): Promise<bigint> => {
+export const spacePledged = async (api: Api): Promise<bigint> => {
   const _solutionRanges = await solutionRanges(api)
   const _slotProbability = slotProbability(api)
 
@@ -92,6 +92,9 @@ export const spacePledge = async (api: Api): Promise<bigint> => {
 
   return totalSpacePledged
 }
+
+// This function is deprecated (use spacePledged instead) and will be removed in a future major release
+export const spacePledge = async (api: Api): Promise<bigint> => spacePledged(api)
 
 export const blockchainSize = async (api: Api): Promise<bigint> => {
   const _segmentCommitment = await segmentCommitment(api)


### PR DESCRIPTION
### **User description**
## Fix spacePledge typo -> spacePledged


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Renamed the `spacePledge` function to `spacePledged` to correct a typo.
- Introduced a deprecated wrapper for the old `spacePledge` function to maintain backward compatibility.
- Added comments to indicate that `spacePledge` is deprecated and will be removed in a future release.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>info.ts</strong><dd><code>Rename and deprecate `spacePledge` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auto-consensus/src/info.ts

<li>Renamed <code>spacePledge</code> function to <code>spacePledged</code>.<br> <li> Added a deprecated wrapper for <code>spacePledge</code> pointing to <code>spacePledged</code>.<br> <li> Updated comments to indicate deprecation.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/auto-sdk/pull/132/files#diff-24b4a9c81e2e7a71bbcd34fde8eee2478d871e8d25cc658151079a091d4d582c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information