### PR TITLE
Remove rpc-1 (deprecated) from gemini-3h

### DIFF
--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -73,10 +73,7 @@ export const networks: Network[] = [
   {
     id: NetworkId.GEMINI_3H,
     name: NetworkName.GEMINI_3H,
-    rpcUrls: [
-      'wss://rpc-0.gemini-3h.subspace.network/ws',
-      'wss://rpc-1.gemini-3h.subspace.network/ws',
-    ],
+    rpcUrls: ['wss://rpc-0.gemini-3h.subspace.network/ws'],
     explorer: [
       {
         name: NetworkExplorerName.ASTRAL,


### PR DESCRIPTION
### **User description**
## Remove rpc-1 (deprecated) from gemini-3h


___

### **PR Type**
enhancement


___

### **Description**
- Removed the deprecated 'rpc-1' URL from the GEMINI_3H network configuration in the `network.ts` file.
- Ensured that only the active 'rpc-0' URL is listed for the GEMINI_3H network.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.ts</strong><dd><code>Remove deprecated RPC URL from GEMINI_3H network configuration</code></dd></summary>
<hr>

packages/auto-utils/src/constants/network.ts

<li>Removed deprecated RPC URL 'rpc-1' from the GEMINI_3H network <br>configuration.<br> <li> Updated the <code>rpcUrls</code> array to only include 'rpc-0'.<br>


</details>


  </td>
  <td><a href="https://github.com/autonomys/auto-sdk/pull/155/files#diff-4fd2dc1471be3439397f28b938666936f488d249dfbac7440079c77f301f041b">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information