### PR TITLE
Add minimum node version requirement

### DIFF
--- a/packages/auto-dag-data/package.json
+++ b/packages/auto-dag-data/package.json
@@ -24,6 +24,9 @@
     ".": "./dist/index.js",
     "./protobuf": "./dist/metadata/onchain/protobuf/onchainMetadata.js"
   },
+  "engines": {
+    "node": ">=20.8.0"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.13",
     "blockstore-core": "^5.0.2",

--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -8,6 +8,9 @@
     "name": "Autonomys",
     "url": "https://autonomys.net"
   },
+  "engines": {
+    "node": ">=20.8.0"
+  },
   "scripts": {
     "build": "tsc"
   },


### PR DESCRIPTION
### **User description**
As we discussed @webbuf/blake3 requires at least `node20` so as well `@autonomys/auto-dag-data` and `@autonomys/auto-drive` do.


___

### **PR Type**
enhancement


___

### **Description**
- Added a minimum Node.js version requirement of 20.8.0 to the `package.json` files of `@autonomys/auto-dag-data` and `@autonomys/auto-drive`.
- Ensures compatibility with dependencies that require Node.js version 20 or higher.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Node.js version requirement to package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auto-dag-data/package.json

- Added a minimum Node.js version requirement of 20.8.0.



</details>


  </td>
  <td><a href="https://github.com/autonomys/auto-sdk/pull/165/files#diff-d25a6afb9a68440953980ed158260a4d583b7df0cd040b64c7041e16c9818bbe">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Node.js version requirement to package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auto-drive/package.json

- Added a minimum Node.js version requirement of 20.8.0.



</details>


  </td>
  <td><a href="https://github.com/autonomys/auto-sdk/pull/165/files#diff-454826650b92c6540b9c21414e751b88f510e3d2b7641716a4c89b07d30fed62">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information