### PR TITLE
Change Subscan URL

### DIFF
--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -26,7 +26,7 @@ export enum NetworkExplorerName {
 }
 
 export const ASTRAL_EXPLORER = 'https://explorer.autonomys.xyz/'
-export const SUBSCAN_EXPLORER = 'https://subspace.subscan.io/'
+export const SUBSCAN_EXPLORER = 'https://autonomys.subscan.io/'
 
 export const networks: Network[] = [
   {


### PR DESCRIPTION
### **User description**
## Change Subscan URL

Subscan Autonomys mainnet explorer is up at https://autonomys.subscan.io/

The old subspace URL is not valid anymore


___

### **PR Type**
enhancement


___

### **Description**
- Updated the Subscan explorer URL in the network constants to point to the new mainnet explorer at `https://autonomys.subscan.io/`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.ts</strong><dd><code>Update Subscan explorer URL for mainnet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/auto-utils/src/constants/network.ts

- Updated the `SUBSCAN_EXPLORER` URL to the new mainnet explorer.



</details>


  </td>
  <td><a href="https://github.com/autonomys/auto-sdk/pull/170/files#diff-4fd2dc1471be3439397f28b938666936f488d249dfbac7440079c77f301f041b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information