### PR TITLE
update: chunk size limitation

### DIFF
--- a/packages/auto-dag-data/src/ipld/builders.ts
+++ b/packages/auto-dag-data/src/ipld/builders.ts
@@ -14,10 +14,10 @@ import {
 
 export interface Builders {
   inlink: (links: CID[], size: number, linkDepth: number, chunkSize: number) => PBNode
-  chunk: (data: Buffer) => PBNode
+  chunk: (data: Buffer, maxNodeSize?: number) => PBNode
   root: (
     links: CID[],
-    size: number,
+    size: bigint,
     linkDepth: number,
     name?: string,
     maxNodeSize?: number,

--- a/packages/auto-dag-data/src/ipld/chunker.ts
+++ b/packages/auto-dag-data/src/ipld/chunker.ts
@@ -42,7 +42,7 @@ export const NODE_METADATA_SIZE =
 
 export const DEFAULT_MAX_CHUNK_SIZE = DEFAULT_NODE_MAX_SIZE - NODE_METADATA_SIZE
 
-const LINK_SIZE_IN_BYTES = 40
+export const LINK_SIZE_IN_BYTES = 40
 export const DEFAULT_MAX_LINK_PER_NODE = Math.floor(DEFAULT_MAX_CHUNK_SIZE / LINK_SIZE_IN_BYTES)
 
 export const processFileToIPLDFormat = (

--- a/packages/auto-dag-data/src/ipld/nodes.ts
+++ b/packages/auto-dag-data/src/ipld/nodes.ts
@@ -14,7 +14,7 @@ export const createFileChunkIpldNode = (
     createNode(
       encodeIPLDNodeData({
         type: MetadataType.FileChunk,
-        size: BigInt(data.length),
+        size: BigInt(data.length).valueOf(),
         linkDepth: 0,
         data,
       }),
@@ -59,7 +59,7 @@ export const createFileInlinkIpldNode = (
     createNode(
       encodeIPLDNodeData({
         type: MetadataType.FileInlink,
-        size: BigInt(size),
+        size: BigInt(size).valueOf(),
         linkDepth,
       }),
       links.map((cid) => ({ Hash: cid })),
@@ -79,7 +79,7 @@ export const createSingleFileIpldNode = (
     encodeIPLDNodeData({
       type: MetadataType.File,
       name,
-      size: BigInt(data.length),
+      size: BigInt(data.length).valueOf(),
       linkDepth: 0,
       data,
       uploadOptions,
@@ -100,7 +100,7 @@ export const createMetadataInlinkIpldNode = (
     createNode(
       encodeIPLDNodeData({
         type: MetadataType.FileInlink,
-        size: BigInt(size),
+        size: BigInt(size).valueOf(),
         linkDepth,
       }),
       links.map((cid) => ({ Hash: cid })),
@@ -116,7 +116,7 @@ export const createSingleMetadataIpldNode = (data: Buffer, name?: string): PBNod
     encodeIPLDNodeData({
       type: MetadataType.Metadata,
       name,
-      size: BigInt(data.length),
+      size: BigInt(data.length).valueOf(),
       linkDepth: 0,
       data,
     }),
@@ -131,7 +131,7 @@ export const createMetadataChunkIpldNode = (
     createNode(
       encodeIPLDNodeData({
         type: MetadataType.MetadataChunk,
-        size: BigInt(data.length),
+        size: BigInt(data.length).valueOf(),
         linkDepth: 0,
         data,
       }),

--- a/packages/auto-dag-data/src/ipld/nodes.ts
+++ b/packages/auto-dag-data/src/ipld/nodes.ts
@@ -74,17 +74,21 @@ export const createSingleFileIpldNode = (
   data: Buffer,
   name?: string,
   uploadOptions?: FileUploadOptions,
+  maxNodeSize: number = DEFAULT_MAX_CHUNK_SIZE,
 ): PBNode =>
-  createNode(
-    encodeIPLDNodeData({
-      type: MetadataType.File,
-      name,
-      size: BigInt(data.length).valueOf(),
-      linkDepth: 0,
-      data,
-      uploadOptions,
-    }),
-    [],
+  ensureNodeMaxSize(
+    createNode(
+      encodeIPLDNodeData({
+        type: MetadataType.File,
+        name,
+        size: BigInt(data.length).valueOf(),
+        linkDepth: 0,
+        data,
+        uploadOptions,
+      }),
+      [],
+    ),
+    maxNodeSize,
   )
 
 // Creates a file ipld node

--- a/packages/auto-dag-data/src/ipld/nodes.ts
+++ b/packages/auto-dag-data/src/ipld/nodes.ts
@@ -1,19 +1,26 @@
 import { CID } from 'multiformats/cid'
 import { FileUploadOptions, OffchainMetadata } from '../metadata/index.js'
 import { encodeIPLDNodeData, MetadataType } from '../metadata/onchain/index.js'
+import { stringifyMetadata } from '../utils/metadata.js'
 import { DEFAULT_MAX_CHUNK_SIZE, ensureNodeMaxSize } from './chunker.js'
 import { createNode, PBNode } from './index.js'
 
 /// Creates a file chunk ipld node
-export const createFileChunkIpldNode = (data: Buffer): PBNode =>
-  createNode(
-    encodeIPLDNodeData({
-      type: MetadataType.FileChunk,
-      size: data.length,
-      linkDepth: 0,
-      data,
-    }),
-    [],
+export const createFileChunkIpldNode = (
+  data: Buffer,
+  maxNodeSize: number = DEFAULT_MAX_CHUNK_SIZE,
+): PBNode =>
+  ensureNodeMaxSize(
+    createNode(
+      encodeIPLDNodeData({
+        type: MetadataType.FileChunk,
+        size: BigInt(data.length),
+        linkDepth: 0,
+        data,
+      }),
+      [],
+    ),
+    maxNodeSize,
   )
 
 // Creates a file ipld node
@@ -21,7 +28,7 @@ export const createFileChunkIpldNode = (data: Buffer): PBNode =>
 // @todo: add the file's metadata
 export const createChunkedFileIpldNode = (
   links: CID[],
-  size: number,
+  size: bigint,
   linkDepth: number,
   name?: string,
   maxNodeSize: number = DEFAULT_MAX_CHUNK_SIZE,
@@ -52,7 +59,7 @@ export const createFileInlinkIpldNode = (
     createNode(
       encodeIPLDNodeData({
         type: MetadataType.FileInlink,
-        size,
+        size: BigInt(size),
         linkDepth,
       }),
       links.map((cid) => ({ Hash: cid })),
@@ -72,7 +79,7 @@ export const createSingleFileIpldNode = (
     encodeIPLDNodeData({
       type: MetadataType.File,
       name,
-      size: data.length,
+      size: BigInt(data.length),
       linkDepth: 0,
       data,
       uploadOptions,
@@ -93,7 +100,7 @@ export const createMetadataInlinkIpldNode = (
     createNode(
       encodeIPLDNodeData({
         type: MetadataType.FileInlink,
-        size,
+        size: BigInt(size),
         linkDepth,
       }),
       links.map((cid) => ({ Hash: cid })),
@@ -109,26 +116,32 @@ export const createSingleMetadataIpldNode = (data: Buffer, name?: string): PBNod
     encodeIPLDNodeData({
       type: MetadataType.Metadata,
       name,
-      size: data.length,
+      size: BigInt(data.length),
       linkDepth: 0,
       data,
     }),
     [],
   )
 
-export const createMetadataChunkIpldNode = (data: Buffer): PBNode =>
-  createNode(
-    encodeIPLDNodeData({
-      type: MetadataType.MetadataChunk,
-      size: data.length,
-      linkDepth: 0,
-      data,
-    }),
+export const createMetadataChunkIpldNode = (
+  data: Buffer,
+  maxNodeSize: number = DEFAULT_MAX_CHUNK_SIZE,
+): PBNode =>
+  ensureNodeMaxSize(
+    createNode(
+      encodeIPLDNodeData({
+        type: MetadataType.MetadataChunk,
+        size: BigInt(data.length),
+        linkDepth: 0,
+        data,
+      }),
+    ),
+    maxNodeSize,
   )
 
 export const createChunkedMetadataIpldNode = (
   links: CID[],
-  size: number,
+  size: bigint,
   linkDepth: number,
   name?: string,
   maxNodeSize: number = DEFAULT_MAX_CHUNK_SIZE,
@@ -153,7 +166,7 @@ export const createFolderIpldNode = (
   links: CID[],
   name: string,
   linkDepth: number,
-  size: number,
+  size: bigint,
   maxNodeSize: number = DEFAULT_MAX_CHUNK_SIZE,
   uploadOptions?: FileUploadOptions,
 ): PBNode =>
@@ -192,7 +205,7 @@ export const createMetadataNode = (
   metadata: OffchainMetadata,
   maxNodeSize: number = DEFAULT_MAX_CHUNK_SIZE,
 ): PBNode => {
-  const data = Buffer.from(JSON.stringify(metadata))
+  const data = Buffer.from(stringifyMetadata(metadata))
 
   return ensureNodeMaxSize(
     createNode(

--- a/packages/auto-dag-data/src/metadata/offchain/file.ts
+++ b/packages/auto-dag-data/src/metadata/offchain/file.ts
@@ -6,21 +6,21 @@ export type OffchainFileMetadata = {
   dataCid: string
   name?: string
   mimeType?: string
-  totalSize: number
+  totalSize: bigint
   totalChunks: number
   chunks: ChunkInfo[]
   uploadOptions?: FileUploadOptions
 }
 
 export interface ChunkInfo {
-  size: number
+  size: bigint
   cid: string
 }
 
 export const fileMetadata = (
   headCID: CID,
   chunks: ChunkInfo[],
-  totalSize: number,
+  totalSize: bigint,
   name?: string | null,
   mimeType?: string | null,
   uploadOptions: FileUploadOptions = {

--- a/packages/auto-dag-data/src/metadata/offchain/folder.ts
+++ b/packages/auto-dag-data/src/metadata/offchain/folder.ts
@@ -29,7 +29,7 @@ export const childrenMetadataFromNode = (node: PBNode): ChildrenMetadata => {
   return {
     type: ipldData.type === MetadataType.File ? 'file' : 'folder',
     cid: cidToString(cidOfNode(node)),
-    totalSize: ipldData.size ?? BigInt(0),
+    totalSize: ipldData.size ?? BigInt(0).valueOf(),
     name: ipldData.name,
   }
 }
@@ -44,7 +44,7 @@ export const folderMetadata = (
 
   return {
     dataCid: cid,
-    totalSize: children.reduce((acc, child) => acc + child.totalSize, BigInt(0)),
+    totalSize: children.reduce((acc, child) => acc + child.totalSize, BigInt(0).valueOf()),
     totalFiles: children.length,
     children,
     type: 'folder',

--- a/packages/auto-dag-data/src/metadata/offchain/folder.ts
+++ b/packages/auto-dag-data/src/metadata/offchain/folder.ts
@@ -7,14 +7,14 @@ interface ChildrenMetadata {
   type: 'folder' | 'file'
   name?: string
   cid: string
-  totalSize: number
+  totalSize: bigint
 }
 
 export type OffchainFolderMetadata = {
   type: 'folder'
   dataCid: string
   name?: string
-  totalSize: number
+  totalSize: bigint
   totalFiles: number
   children: ChildrenMetadata[]
   uploadOptions: FileUploadOptions
@@ -29,7 +29,7 @@ export const childrenMetadataFromNode = (node: PBNode): ChildrenMetadata => {
   return {
     type: ipldData.type === MetadataType.File ? 'file' : 'folder',
     cid: cidToString(cidOfNode(node)),
-    totalSize: ipldData.size ?? 0,
+    totalSize: ipldData.size ?? BigInt(0),
     name: ipldData.name,
   }
 }
@@ -44,7 +44,7 @@ export const folderMetadata = (
 
   return {
     dataCid: cid,
-    totalSize: children.reduce((acc, child) => acc + child.totalSize, 0),
+    totalSize: children.reduce((acc, child) => acc + child.totalSize, BigInt(0)),
     totalFiles: children.length,
     children,
     type: 'folder',

--- a/packages/auto-dag-data/src/metadata/onchain/protobuf/OnchainMetadata.proto
+++ b/packages/auto-dag-data/src/metadata/onchain/protobuf/OnchainMetadata.proto
@@ -1,12 +1,13 @@
 syntax = "proto3";
 
 message IPLDNodeData {
-  MetadataType type = 1;
-  int32 linkDepth = 2;
-  optional int32 size = 3;
-  optional string name = 4;
-  optional bytes data = 5;
-  optional FileUploadOptions uploadOptions = 6;
+  MetadataType type = 1; // maxLength = 1
+  int32 linkDepth = 2; // maxLength = 4
+  optional int64 size = 3; // maxLength = 8
+  optional string name = 4; // maxLength = 256
+  optional bytes data = 5; // maxLength = XXX
+  optional FileUploadOptions uploadOptions = 6; // maxLength = 100
+  /// Reserve 100 bytes for future use
 }
 
 // MetadataType defines the possible types of metadata.

--- a/packages/auto-dag-data/src/metadata/onchain/protobuf/OnchainMetadata.ts
+++ b/packages/auto-dag-data/src/metadata/onchain/protobuf/OnchainMetadata.ts
@@ -10,7 +10,7 @@ import type { Uint8ArrayList } from 'uint8arraylist'
 export interface IPLDNodeData {
   type: MetadataType
   linkDepth: number
-  size?: number
+  size?: bigint
   name?: string
   data?: Uint8Array
   uploadOptions?: FileUploadOptions
@@ -38,7 +38,7 @@ export namespace IPLDNodeData {
 
         if (obj.size != null) {
           w.uint32(24)
-          w.int32(obj.size)
+          w.int64(obj.size)
         }
 
         if (obj.name != null) {
@@ -80,7 +80,7 @@ export namespace IPLDNodeData {
               break
             }
             case 3: {
-              obj.size = reader.int32()
+              obj.size = reader.int64()
               break
             }
             case 4: {

--- a/packages/auto-dag-data/src/utils/metadata.ts
+++ b/packages/auto-dag-data/src/utils/metadata.ts
@@ -1,0 +1,6 @@
+import { OffchainMetadata } from '../metadata/index.js'
+
+export const stringifyMetadata = (metadata: OffchainMetadata): string =>
+  JSON.stringify(metadata, (_, v) =>
+    typeof v === 'bigint' || v instanceof BigInt ? v.toString() : v,
+  )

--- a/packages/auto-dag-data/tests/chunker.spec.ts
+++ b/packages/auto-dag-data/tests/chunker.spec.ts
@@ -200,7 +200,7 @@ describe('chunker', () => {
         dataCid: 'test',
         name: 'test',
         mimeType: 'text/plain',
-        totalSize: 1000,
+        totalSize: BigInt(1000),
         totalChunks: 10,
         chunks: [],
       }
@@ -217,7 +217,7 @@ describe('chunker', () => {
         dataCid: 'test',
         name: 'test',
         mimeType: 'text/plain'.repeat(100),
-        totalSize: 1000,
+        totalSize: BigInt(1000),
         totalChunks: 10,
         chunks: [],
       }

--- a/packages/auto-dag-data/tests/chunker.spec.ts
+++ b/packages/auto-dag-data/tests/chunker.spec.ts
@@ -16,7 +16,12 @@ describe('chunker', () => {
       const name = 'test.txt'
       const blockstore = new MemoryBlockstore()
 
-      await processFileToIPLDFormat(blockstore, bufferToIterable(Buffer.from(text)), size, name)
+      await processFileToIPLDFormat(
+        blockstore,
+        bufferToIterable(Buffer.from(text)),
+        BigInt(size),
+        name,
+      )
       const nodes = await nodesFromBlockstore(blockstore)
       expect(nodes.length).toBe(1)
 
@@ -31,7 +36,7 @@ describe('chunker', () => {
       expect(decoded.type).toBe(MetadataType.File)
       expect(Buffer.from(decoded.data ?? '').toString()).toBe(text)
       expect(decoded.linkDepth).toBe(0)
-      expect(decoded.size).toBe(text.length)
+      expect(decoded.size?.toString()).toBe(text.length.toString())
 
       /// Check no links
       expect(node?.Links.length).toBe(0)
@@ -52,7 +57,7 @@ describe('chunker', () => {
       const headCID = await processFileToIPLDFormat(
         blockstore,
         bufferToIterable(Buffer.from(text)),
-        size,
+        BigInt(size),
         name,
         {
           maxChunkSize,
@@ -72,7 +77,7 @@ describe('chunker', () => {
       expect(decoded.name).toBe(name)
       expect(decoded.type).toBe(MetadataType.File)
       expect(decoded.linkDepth).toBe(1)
-      expect(decoded.size).toBe(text.length)
+      expect(decoded.size!.toString()).toBe(text.length.toString())
 
       nodes.forEach((node) => {
         if (cidToString(cidOfNode(node)) !== cidToString(headCID)) {
@@ -96,7 +101,7 @@ describe('chunker', () => {
       const headCID = await processFileToIPLDFormat(
         blockstore,
         bufferToIterable(Buffer.from(text)),
-        size,
+        BigInt(size),
         name,
         {
           maxChunkSize,
@@ -136,7 +141,7 @@ describe('chunker', () => {
       const name = 'folder'
       const size = 1000
       const blockstore = new MemoryBlockstore()
-      const headCID = processFolderToIPLDFormat(blockstore, links, name, size, {
+      const headCID = processFolderToIPLDFormat(blockstore, links, name, BigInt(size), {
         maxLinkPerNode: 4,
       })
 
@@ -149,7 +154,7 @@ describe('chunker', () => {
       expect(decoded.name).toBe(name)
       expect(decoded.type).toBe(MetadataType.Folder)
       expect(decoded.linkDepth).toBe(0)
-      expect(decoded.size).toBe(size)
+      expect(decoded.size!.toString()).toBe(size.toString())
     })
 
     it('create a folder dag with inlinks', async () => {
@@ -163,7 +168,7 @@ describe('chunker', () => {
       const EXPECTED_NODE_COUNT = 4
 
       const blockstore = new MemoryBlockstore()
-      const headCID = processFolderToIPLDFormat(blockstore, links, name, size, {
+      const headCID = processFolderToIPLDFormat(blockstore, links, name, BigInt(size), {
         maxLinkPerNode: 4,
       })
 
@@ -235,13 +240,13 @@ describe('chunker', () => {
       const singleBufferCID = await processFileToIPLDFormat(
         blockstore,
         bufferToIterable(buffer),
-        buffer.length,
+        BigInt(buffer.length),
         'test.txt',
       )
       const chunkedBufferCID = await processFileToIPLDFormat(
         chunkedBlockstore,
         separateBufferToIterable(buffer, 5),
-        buffer.length,
+        BigInt(buffer.length),
         'test.txt',
       )
 
@@ -255,13 +260,13 @@ describe('chunker', () => {
       const singleBufferCID = await processFileToIPLDFormat(
         blockstore,
         bufferToIterable(buffer),
-        buffer.length,
+        BigInt(buffer.length),
         'test.txt',
       )
       const chunkedBufferCID = await processFileToIPLDFormat(
         chunkedBlockstore,
         separateBufferToIterable(buffer, 5),
-        buffer.length,
+        BigInt(buffer.length),
         'test.txt',
       )
 

--- a/packages/auto-dag-data/tests/nodes.spec.ts
+++ b/packages/auto-dag-data/tests/nodes.spec.ts
@@ -15,7 +15,7 @@ describe('node creation', () => {
       const node = createSingleFileIpldNode(buffer, filename)
       const decoded = IPLDNodeData.decode(node.Data ?? new Uint8Array())
       expect(decoded.name).toBe(filename)
-      expect(decoded.size).toBe(buffer.length)
+      expect(decoded.size!.toString()).toBe(buffer.length.toString())
       expect(Buffer.from(decoded.data ?? '').toString()).toBe(buffer.toString())
     })
 
@@ -25,7 +25,7 @@ describe('node creation', () => {
       const decoded = IPLDNodeData.decode(node.Data ?? new Uint8Array())
       expect(decoded.type).toBe(MetadataType.File)
       expect(decoded.name).toBeUndefined()
-      expect(decoded.size).toBe(buffer.length)
+      expect(decoded.size!.toString()).toBe(buffer.length.toString())
       expect(Buffer.from(decoded.data ?? '').toString()).toBe(buffer.toString())
     })
 
@@ -33,15 +33,15 @@ describe('node creation', () => {
       const links = Array.from({ length: 10 }, () =>
         cidOfNode(createNode(Buffer.from(Math.random().toString()))),
       )
-      const size = 1000
+      const size = BigInt(1000)
       const linkDepth = 1
       const filename = 'test.txt'
-      const node = createChunkedFileIpldNode(links, size, linkDepth, filename)
+      const node = createChunkedFileIpldNode(links, BigInt(size), linkDepth, filename)
 
       const decoded = IPLDNodeData.decode(node.Data ?? new Uint8Array())
       expect(decoded.type).toBe(MetadataType.File)
       expect(decoded.name).toBe(filename)
-      expect(decoded.size).toBe(size)
+      expect(decoded.size!.toString()).toBe(size.toString())
       expect(decoded.linkDepth).toBe(linkDepth)
     })
 
@@ -49,14 +49,14 @@ describe('node creation', () => {
       const links = Array.from({ length: 10 }, () =>
         cidOfNode(createNode(Buffer.from(Math.random().toString()))),
       )
-      const size = 1000
+      const size = BigInt(1000)
       const linkDepth = 1
       const node = createChunkedFileIpldNode(links, size, linkDepth)
 
       const decoded = IPLDNodeData.decode(node.Data ?? new Uint8Array())
       expect(decoded.type).toBe(MetadataType.File)
       expect(decoded.name).toBeUndefined()
-      expect(decoded.size).toBe(size)
+      expect(decoded.size!.toString()).toBe(size.toString())
       expect(decoded.linkDepth).toBe(linkDepth)
     })
 
@@ -67,7 +67,7 @@ describe('node creation', () => {
       const decoded = IPLDNodeData.decode(node.Data ?? new Uint8Array())
       expect(decoded.type).toBe(MetadataType.FileChunk)
       expect(decoded.name).toBeUndefined()
-      expect(decoded.size).toBe(buffer.length)
+      expect(decoded.size!.toString()).toBe(buffer.length.toString())
       expect(decoded.linkDepth).toBe(0)
     })
   })

--- a/packages/auto-dag-data/tests/nodes.spec.ts
+++ b/packages/auto-dag-data/tests/nodes.spec.ts
@@ -4,7 +4,7 @@ import {
   createFileChunkIpldNode,
   createSingleFileIpldNode,
 } from '../src/index.js'
-import { createNode } from '../src/ipld/index.js'
+import { createNode, DEFAULT_MAX_CHUNK_SIZE } from '../src/ipld/index.js'
 import { IPLDNodeData, MetadataType } from '../src/metadata/onchain/protobuf/OnchainMetadata.js'
 
 describe('node creation', () => {
@@ -27,6 +27,12 @@ describe('node creation', () => {
       expect(decoded.name).toBeUndefined()
       expect(decoded.size!.toString()).toBe(buffer.length.toString())
       expect(Buffer.from(decoded.data ?? '').toString()).toBe(buffer.toString())
+    })
+
+    it('single file root node | buffer too large', () => {
+      const maxNodeSize = DEFAULT_MAX_CHUNK_SIZE
+      const buffer = Buffer.from('h'.repeat(maxNodeSize))
+      expect(() => createSingleFileIpldNode(buffer, 'test.txt')).toThrow()
     })
 
     it('chunked file root node | correctly params setup', () => {


### PR DESCRIPTION
IPLD node byte length limit was not strict since extrinsic are limited >> 64kb when a hexadecimal string is sent as data. Since it's intended to publish IPLD nodes in binary format (limited to 65535 bytes) a strict limit is needed. 

The calculated chunk limit (and maxLinksPerNode ) comes from the 64kb limit minus the maximum size of the IPLD metadata.

