### PR TITLE
Add auto-evm taurus and change domain name

### DIFF
--- a/packages/auto-utils/src/constants/domain.ts
+++ b/packages/auto-utils/src/constants/domain.ts
@@ -4,15 +4,15 @@ import { Domains } from '../types/domain'
 
 export enum DomainRuntime {
   AUTO_ID = 'auto-id',
-  NOVA = 'nova',
+  AUTO_EVM = 'auto-evm',
 }
 
 export const domains: Domains = {
-  [DomainRuntime.AUTO_ID]: {
-    runtime: DomainRuntime.NOVA,
-    name: 'Nova (EVM)',
+  [DomainRuntime.AUTO_EVM]: {
+    runtime: DomainRuntime.AUTO_EVM,
+    name: 'Auto-EVM',
   },
-  [DomainRuntime.NOVA]: {
+  [DomainRuntime.AUTO_ID]: {
     runtime: DomainRuntime.AUTO_ID,
     name: 'Auto-ID',
   },

--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -66,7 +66,18 @@ export const networks: Network[] = [
         url: ASTRAL_EXPLORER + 'taurus/consensus/',
       },
     ],
-    domains: [],
+    domains: [
+      {
+        domainId: '0',
+        ...domains[DomainRuntime.AUTO_EVM],
+        rpcUrls: [
+          'wss://auto-evm-0.taurus.subspace.network/ws',
+          'wss://auto-evm-1.taurus.subspace.network/ws',
+          'wss://auto-evm-0.taurus.autonomys.xyz/ws',
+          'wss://auto-evm-1.taurus.autonomys.xyz/ws',
+        ],
+      },
+    ],
     token: TESTNET_TOKEN,
     isTestnet: true,
   },
@@ -83,7 +94,7 @@ export const networks: Network[] = [
     domains: [
       {
         domainId: '0',
-        ...domains[DomainRuntime.NOVA],
+        ...domains[DomainRuntime.AUTO_EVM],
         rpcUrls: ['wss://nova-0.gemini-3h.subspace.network/ws'],
       },
       {
@@ -108,7 +119,7 @@ export const networks: Network[] = [
     domains: [
       {
         domainId: '0',
-        ...domains[DomainRuntime.NOVA],
+        ...domains[DomainRuntime.AUTO_EVM],
         rpcUrls: ['wss:///nova.devnet.subspace.network/ws'],
       },
       {
@@ -134,13 +145,13 @@ export const networks: Network[] = [
     domains: [
       {
         domainId: '0',
-        ...domains[DomainRuntime.NOVA],
-        rpcUrls: ['ws:///127.0.0.1:9946/ws'],
+        ...domains[DomainRuntime.AUTO_EVM],
+        rpcUrls: ['ws://127.0.0.1:9945/ws'],
       },
       {
         domainId: '1',
         ...domains[DomainRuntime.AUTO_ID],
-        rpcUrls: ['ws://127.0.0.1:9945/ws'],
+        rpcUrls: ['ws:///127.0.0.1:9946/ws'],
       },
     ],
     token: TESTNET_TOKEN,

--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -71,6 +71,7 @@ export const networks: Network[] = [
         domainId: '0',
         ...domains[DomainRuntime.AUTO_EVM],
         rpcUrls: [
+          'wss://auto-evm.taurus.subspace.network/ws',
           'wss://auto-evm-0.taurus.subspace.network/ws',
           'wss://auto-evm-1.taurus.subspace.network/ws',
           'wss://auto-evm-0.taurus.autonomys.xyz/ws',

--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -151,7 +151,7 @@ export const networks: Network[] = [
       {
         domainId: '1',
         ...domains[DomainRuntime.AUTO_ID],
-        rpcUrls: ['ws:///127.0.0.1:9946/ws'],
+        rpcUrls: ['ws://127.0.0.1:9946/ws'],
       },
     ],
     token: TESTNET_TOKEN,


### PR DESCRIPTION
## Add auto-evm taurus and change domain name

- Change Nova for Auto-EVM
- Add future auto-evm domain rpc urls