### PR TITLE
Fix few issues in auto-drive pkg

### DIFF
--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -22,6 +22,7 @@
     "@autonomys/auto-dag-data": "^1.0.10",
     "jszip": "^3.10.1",
     "mime-types": "^2.1.35",
+    "rxjs": "^7.8.1",
     "zod": "^3.23.8"
   },
   "gitHead": "9b727721d65d5ee5b8eea9e6999f24146590174c"

--- a/packages/auto-drive/src/api/calls/read.ts
+++ b/packages/auto-drive/src/api/calls/read.ts
@@ -1,5 +1,6 @@
 import { ArgsWithoutPagination, ArgsWithPagination } from '../../utils/types.js'
 import { AutoDriveApi } from '../connection.js'
+import { PaginatedResult } from '../models/common.js'
 import { ObjectInformation, ObjectSummary, Scope } from '../models/objects.js'
 
 /**
@@ -13,7 +14,7 @@ import { ObjectInformation, ObjectSummary, Scope } from '../models/objects.js'
 export const getRoots = async (
   api: AutoDriveApi,
   query: ArgsWithPagination<{ scope: Scope }>,
-): Promise<ObjectSummary[]> => {
+): Promise<PaginatedResult<ObjectSummary>> => {
   const response = await api.sendRequest(
     `/objects/roots?scope=${query.scope}&limit=${query.limit}&offset=${query.offset}`,
     {
@@ -42,7 +43,7 @@ export const getRoots = async (
 export const getSharedWithMe = async (
   api: AutoDriveApi,
   query: ArgsWithPagination,
-): Promise<ObjectSummary[]> => {
+): Promise<PaginatedResult<ObjectSummary>> => {
   const response = await api.sendRequest(
     `/objects/roots/shared?limit=${query.limit}&offset=${query.offset}`,
     {
@@ -71,7 +72,7 @@ export const getSharedWithMe = async (
 export const getDeleted = async (
   api: AutoDriveApi,
   query: ArgsWithPagination,
-): Promise<ObjectSummary[]> => {
+): Promise<PaginatedResult<ObjectSummary>> => {
   const response = await api.sendRequest(
     `/objects/roots/deleted?limit=${query.limit}&offset=${query.offset}`,
     {

--- a/packages/auto-drive/src/api/models/common.ts
+++ b/packages/auto-drive/src/api/models/common.ts
@@ -1,0 +1,4 @@
+export type PaginatedResult<T> = {
+  rows: T[]
+  totalCount: number
+}

--- a/packages/auto-drive/src/utils/observable.ts
+++ b/packages/auto-drive/src/utils/observable.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom, lastValueFrom, Observable, Subscriber } from 'rxjs'
+import rxjs from 'rxjs'
 
 const asyncCallback = <T, O>(callback: (t: T) => O) => {
   return (t: T) => {
@@ -6,8 +6,8 @@ const asyncCallback = <T, O>(callback: (t: T) => O) => {
   }
 }
 
-export class PromisedObservable<T> extends Observable<T> {
-  constructor(subscribe?: (this: Observable<T>, subscriber: Subscriber<T>) => void) {
+export class PromisedObservable<T> extends rxjs.Observable<T> {
+  constructor(subscribe?: (this: rxjs.Observable<T>, subscriber: rxjs.Subscriber<T>) => void) {
     super(subscribe && asyncCallback(subscribe))
   }
 
@@ -16,4 +16,4 @@ export class PromisedObservable<T> extends Observable<T> {
   }
 }
 
-export { firstValueFrom, lastValueFrom }
+export const { firstValueFrom, lastValueFrom } = rxjs

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,7 @@ __metadata:
     "@types/mime-types": "npm:^2"
     jszip: "npm:^3.10.1"
     mime-types: "npm:^2.1.35"
+    rxjs: "npm:^7.8.1"
     typescript: "npm:^5.6.3"
     zod: "npm:^3.23.8"
   languageName: unknown


### PR DESCRIPTION
Creating the examples for interacting with auto-drive backend I came out with some issues:

- 1. Wrongly typed paginated responses: It didn't consider pagination


- 2. RXJS is a commonjs package that in a ESM enviroment should be imported in this way:

```ts
import rxjs from 'rxjs'
```

rather than:

```ts
import {xyz} from 'rxjs'
```