### PR TITLE
Update API url

### DIFF
--- a/packages/auto-drive/src/api/connection.ts
+++ b/packages/auto-drive/src/api/connection.ts
@@ -17,7 +17,7 @@ export type AuthProvider = ApiKeyAuthProvider | 'oauth'
 export const createAutoDriveApi = ({
   provider = 'apikey',
   apiKey,
-  url = 'https://demo.auto-drive.autonomys.xyz',
+  url = 'https://demo.auto-drive.autonomys.xyz/api',
 }: {
   provider?: AuthProvider
   apiKey: string


### PR DESCRIPTION
As described in the nginx config in this [PR](https://github.com/autonomys/auto-drive/pull/113), default URL has changed to have the postfix /api