### PR TITLE
Fix environmental issues

### DIFF
--- a/packages/auto-dag-data/src/encryption/index.ts
+++ b/packages/auto-dag-data/src/encryption/index.ts
@@ -1,12 +1,11 @@
 import { Crypto } from '@peculiar/webcrypto'
-import { randomBytes } from 'crypto'
 import { AwaitIterable } from 'interface-store'
 import { EncryptionAlgorithm, EncryptionOptions } from '../metadata/index.js'
 import { asyncByChunk } from '../utils/async.js'
 import type { PickPartial } from '../utils/types.js'
 import { PasswordGenerationOptions } from './types.js'
 
-const crypto = new Crypto()
+export const crypto = typeof window === 'undefined' ? new Crypto() : window.crypto
 
 export const ENCRYPTING_CHUNK_SIZE = 1024 * 1024
 const IV_SIZE = 16
@@ -50,7 +49,7 @@ export const encryptFile = async function* (
     throw new Error('Unsupported encryption algorithm')
   }
 
-  const salt = randomBytes(SALT_SIZE)
+  const salt = crypto.getRandomValues(Buffer.alloc(SALT_SIZE))
   const key = await getKeyFromPassword({ password, salt })
 
   yield salt

--- a/packages/auto-drive/src/utils/observable.ts
+++ b/packages/auto-drive/src/utils/observable.ts
@@ -1,4 +1,4 @@
-import rxjs from 'rxjs'
+import * as rxjs from 'rxjs'
 
 const asyncCallback = <T, O>(callback: (t: T) => O) => {
   return (t: T) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11389,7 +11389,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
   version: 5.7.2
-  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=cef18b"
+  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver

--- a/yarn.lock
+++ b/yarn.lock
@@ -11389,7 +11389,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
   version: 5.7.2
-  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=cef18b"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
Adding examples to auto-drive backend I figured out that there were some issues using the package in web clients. These fixes are to solved them. These changes work also in nodejs server. 

For making this version work on the web client some webpack config is needed to be setup. I'll add an issue for solving this internally so no webpack is needed.