### PR TITLE
Abstraction of CID to provide several returning types

### DIFF
--- a/packages/auto-drive/src/api/models/uploads.ts
+++ b/packages/auto-drive/src/api/models/uploads.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { AutoCID } from '../../utils/autohash'
 import { FolderTreeFolderSchema } from './folderTree'
 
 export enum UploadType {
@@ -79,7 +80,7 @@ export type UploadFileStatus =
       completed: true
       type: 'file'
       progress: number
-      cid: string
+      cid: AutoCID
     }
   | {
       completed: false
@@ -93,7 +94,7 @@ export type UploadFolderStatus =
       completed: true
       type: 'folder'
       progress: number
-      cid: string
+      cid: AutoCID
     }
   | {
       completed: false

--- a/packages/auto-drive/src/api/wrappers.ts
+++ b/packages/auto-drive/src/api/wrappers.ts
@@ -1,5 +1,6 @@
 import mime from 'mime-types'
 import { asyncByChunk, asyncFromStream, fileToIterable } from '../utils/async'
+import { AutoCID } from '../utils/autohash'
 import { progressToPercentage } from '../utils/misc'
 import { PromisedObservable } from '../utils/observable'
 import { apiCalls } from './calls/index'
@@ -110,7 +111,7 @@ export const uploadFileFromInput = (
       type: 'file',
       progress: 100,
       completed: true,
-      cid: result.cid,
+      cid: await AutoCID.create(result.cid),
     })
     subscriber.complete()
   })
@@ -193,7 +194,7 @@ export const uploadFile = (
       type: 'file',
       progress: 100,
       completed: true,
-      cid: result.cid,
+      cid: await AutoCID.create(result.cid),
     })
     subscriber.complete()
   })
@@ -285,7 +286,7 @@ export const uploadFolderFromInput = async (
       type: 'folder',
       progress: 100,
       completed: true,
-      cid: result.cid,
+      cid: await AutoCID.create(result.cid),
     })
     subscriber.complete()
   })

--- a/packages/auto-drive/src/fs/wrappers.ts
+++ b/packages/auto-drive/src/fs/wrappers.ts
@@ -6,6 +6,7 @@ import { GenericFileWithinFolder } from '../api/models/file.js'
 import { constructFromFileSystemEntries } from '../api/models/folderTree.js'
 import { UploadFileStatus, UploadFolderStatus } from '../api/models/uploads.js'
 import { uploadFile, UploadFileOptions, uploadFileWithinFolderUpload } from '../api/wrappers.js'
+import { AutoCID } from '../utils/autohash.js'
 import { fileToIterable } from '../utils/index.js'
 import { progressToPercentage } from '../utils/misc.js'
 import { PromisedObservable } from '../utils/observable.js'
@@ -139,7 +140,7 @@ export const uploadFolderFromFolderPath = async (
       type: 'folder',
       progress: 100,
       completed: true,
-      cid: result.cid,
+      cid: await AutoCID.create(result.cid),
     })
     subscriber.complete()
   })

--- a/packages/auto-drive/src/utils/autohash.ts
+++ b/packages/auto-drive/src/utils/autohash.ts
@@ -1,0 +1,39 @@
+import type { CID } from 'multiformats/cid'
+
+interface AutoCIDTransformers {
+  stringToCid: (cid: string) => CID
+  blake3HashFromCid: (cid: CID) => Uint8Array
+}
+
+export class AutoCID {
+  constructor(
+    private readonly cid: string,
+    private readonly tools: AutoCIDTransformers,
+  ) {}
+
+  static async create(cid: string): Promise<AutoCID> {
+    const tools = await getToolsFromAutoDagData
+    return new AutoCID(cid, tools)
+  }
+
+  get asString(): string {
+    return this.cid
+  }
+
+  get asCID(): CID {
+    return this.tools.stringToCid(this.cid)
+  }
+
+  get asBlake3Hash(): Buffer {
+    return Buffer.from(this.tools.blake3HashFromCid(this.asCID))
+  }
+}
+
+export const getToolsFromAutoDagData: Promise<AutoCIDTransformers> = import(
+  '@autonomys/auto-dag-data'
+).then(({ stringToCid, blake3HashFromCid }) => {
+  return {
+    stringToCid,
+    blake3HashFromCid,
+  }
+})


### PR DESCRIPTION
@jfrank-summit @marc-aurele-besner What do you think about this solution for the issue of easing the conversion into blake3hash, CID string or any other derived form of CID. For asynchronous functions should work fine.

We had commented about using an optional verbose argument but I don't like quite much varying the returning type depending on the input. 