### PR TITLE
Fix missing dependency

### DIFF
--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@autonomys/auto-dag-data": "^1.2.6",
+    "@autonomys/auto-utils": "^1.2.6",
     "jszip": "^3.10.1",
     "mime-types": "^2.1.35",
     "process": "^0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,7 @@ __metadata:
   resolution: "@autonomys/auto-drive@workspace:packages/auto-drive"
   dependencies:
     "@autonomys/auto-dag-data": "npm:^1.2.6"
+    "@autonomys/auto-utils": "npm:^1.2.6"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.1"
     "@rollup/plugin-json": "npm:^6.1.0"


### PR DESCRIPTION
Pkg `@autonomys/auto-utils` is used in `@autonomys/auto-drive` pkg but wasn't a dependency