### PR TITLE
Add formatSpaceToBinaryAsObject and formatSpaceToDecimalAsObject

### DIFF
--- a/packages/auto-consensus/src/utils/format.ts
+++ b/packages/auto-consensus/src/utils/format.ts
@@ -1,6 +1,9 @@
 // Binary format (powers of 2)
-export const formatSpaceToBinary = (value: number, decimals = 2) => {
-  if (value === 0) return '0 Bytes'
+export const formatSpaceToBinaryAsObject = (
+  value: number,
+  decimals = 2,
+): { value: number; unit: string } => {
+  if (value === 0) return { value: 0, unit: 'Bytes' }
 
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals
@@ -8,12 +11,15 @@ export const formatSpaceToBinary = (value: number, decimals = 2) => {
 
   const i = Math.floor(Math.log(value) / Math.log(k))
 
-  return parseFloat((value / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
+  return { value: parseFloat((value / Math.pow(k, i)).toFixed(dm)), unit: sizes[i] }
 }
 
 // Decimal format (powers of 10)
-export const formatSpaceToDecimal = (value: number, decimals = 2) => {
-  if (value === 0) return '0 Bytes'
+export const formatSpaceToDecimalAsObject = (
+  value: number,
+  decimals = 2,
+): { value: number; unit: string } => {
+  if (value === 0) return { value: 0, unit: 'Bytes' }
 
   const k = 1000
   const dm = decimals < 0 ? 0 : decimals
@@ -21,5 +27,21 @@ export const formatSpaceToDecimal = (value: number, decimals = 2) => {
 
   const i = Math.floor(Math.log(value) / Math.log(k))
 
-  return parseFloat((value / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
+  return { value: parseFloat((value / Math.pow(k, i)).toFixed(dm)), unit: sizes[i] }
+}
+
+// Binary format (powers of 2)
+export const formatSpaceToBinary = (value: number, decimals = 2): string => {
+  if (value === 0) return '0 Bytes'
+
+  const { value: formattedValue, unit } = formatSpaceToBinaryAsObject(value, decimals)
+  return `${formattedValue} ${unit}`
+}
+
+// Decimal format (powers of 10)
+export const formatSpaceToDecimal = (value: number, decimals = 2): string => {
+  if (value === 0) return '0 Bytes'
+
+  const { value: formattedValue, unit } = formatSpaceToDecimalAsObject(value, decimals)
+  return `${formattedValue} ${unit}`
 }


### PR DESCRIPTION
## Add formatSpaceToBinaryAsObject and formatSpaceToDecimalAsObject

This is to allow us to use the number separately from the label (and so for example adding animation to the number if between two query it increase)