### PR TITLE
Published v1.4.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "examples/*"
   ],
   "scripts": {
-    "prebuild": "yarn build @autonomys/asynchronous",
     "build": "lerna run build",
     "clean": "lerna run clean",
     "format": "lerna run format",

--- a/packages/asynchronous/package.json
+++ b/packages/asynchronous/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/asynchronous",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/auto-consensus/package.json
+++ b/packages/auto-consensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-consensus",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-utils": "^1.4.0"
+    "@autonomys/auto-utils": "^1.4.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/auto-dag-data/package.json
+++ b/packages/auto-dag-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-dag-data",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-drive",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@autonomys/asynchronous": "workspace:*",
-    "@autonomys/auto-dag-data": "^1.4.0",
-    "@autonomys/auto-utils": "^1.4.0",
+    "@autonomys/auto-dag-data": "^1.4.1",
+    "@autonomys/auto-utils": "^1.4.1",
     "jszip": "^3.10.1",
     "mime-types": "^2.1.35",
     "process": "^0.11.10",

--- a/packages/auto-utils/package.json
+++ b/packages/auto-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-utils",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/packages/auto-xdm/package.json
+++ b/packages/auto-xdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-xdm",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,8 +25,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-consensus": "^1.4.0",
-    "@autonomys/auto-utils": "^1.4.0"
+    "@autonomys/auto-consensus": "^1.4.1",
+    "@autonomys/auto-utils": "^1.4.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,11 +36,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-consensus@npm:^1.4.0, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
+"@autonomys/auto-consensus@npm:^1.4.1, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-consensus@workspace:packages/auto-consensus"
   dependencies:
-    "@autonomys/auto-utils": "npm:^1.4.0"
+    "@autonomys/auto-utils": "npm:^1.4.1"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.22.0"
     jest: "npm:^29.7.0"
@@ -50,7 +50,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-dag-data@npm:^1.4.0, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
+"@autonomys/auto-dag-data@npm:^1.4.1, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-dag-data@workspace:packages/auto-dag-data"
   dependencies:
@@ -79,8 +79,8 @@ __metadata:
   resolution: "@autonomys/auto-drive@workspace:packages/auto-drive"
   dependencies:
     "@autonomys/asynchronous": "workspace:*"
-    "@autonomys/auto-dag-data": "npm:^1.4.0"
-    "@autonomys/auto-utils": "npm:^1.4.0"
+    "@autonomys/auto-dag-data": "npm:^1.4.1"
+    "@autonomys/auto-utils": "npm:^1.4.1"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"
     "@rollup/plugin-json": "npm:^6.1.0"
@@ -113,7 +113,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-utils@npm:^1.4.0, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
+"@autonomys/auto-utils@npm:^1.4.1, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-utils@workspace:packages/auto-utils"
   dependencies:
@@ -136,8 +136,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-xdm@workspace:packages/auto-xdm"
   dependencies:
-    "@autonomys/auto-consensus": "npm:^1.4.0"
-    "@autonomys/auto-utils": "npm:^1.4.0"
+    "@autonomys/auto-consensus": "npm:^1.4.1"
+    "@autonomys/auto-utils": "npm:^1.4.1"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.22.0"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
The standalone publication of the @autonomys/asynchronous v.1.4.0 was missing the compiled package. 