### PR TITLE
Feat: Add more XDM function

### DIFF
--- a/packages/auto-xdm/src/index.ts
+++ b/packages/auto-xdm/src/index.ts
@@ -1,2 +1,3 @@
 export * from './info'
+export * from './messenger'
 export * from './transfer'

--- a/packages/auto-xdm/src/info.ts
+++ b/packages/auto-xdm/src/info.ts
@@ -1,11 +1,19 @@
 // file: src/types/index.ts
 
 import { query } from '@autonomys/auto-consensus'
-import type { ApiPromise, Codec } from '@autonomys/auto-utils'
+import { createDomainsChainIdType, type ApiPromise, type Codec } from '@autonomys/auto-utils'
 
-export const chainAllowlist = async (api: ApiPromise) => {
-  return await query<Codec>(api, 'messenger.chainAllowlist', [])
-}
+export const chainAllowlist = async (api: ApiPromise) =>
+  await query<Codec>(api, 'messenger.chainAllowlist', [])
+
+export const channels = async (api: ApiPromise, chainId: Codec) =>
+  await query<Codec>(api, 'messenger.channels', [chainId])
+
+export const consensusChannels = async (api: ApiPromise) =>
+  await query<Codec>(api, 'messenger.channels', [createDomainsChainIdType(api)])
+
+export const domainChannels = async (api: ApiPromise, domainId: number) =>
+  await query<Codec>(api, 'messenger.channels', [createDomainsChainIdType(api, domainId)])
 
 export const allCancelledTransfers = async (api: ApiPromise) => {
   return await query<Codec>(api, 'transporter.cancelledTransfers', [])

--- a/packages/auto-xdm/src/messenger.ts
+++ b/packages/auto-xdm/src/messenger.ts
@@ -1,0 +1,11 @@
+// file: src/transfer.ts
+
+import type { ApiPromise, Codec } from '@autonomys/auto-utils'
+
+export const initiateChannel = async (api: ApiPromise, destination: Codec) => {
+  return await api.tx.messenger.initiateChannel(destination)
+}
+
+export const closeChannel = async (api: ApiPromise, chainId: Codec, channelId: string) => {
+  return await api.tx.messenger.closeChannel(chainId, channelId)
+}


### PR DESCRIPTION
## Feat: Add more XDM function

This pull request includes several changes to the `packages/auto-xdm` module, focusing on exporting new functionalities and adding new methods to handle messenger channels. The most important changes are grouped by theme and listed below:

### Export and Imports:

* [`packages/auto-xdm/src/index.ts`](diffhunk://#diff-1890068248bde88db321056bacc97c7550d1d24e19dc50075ccbd469114ae865R2): Added export for `messenger` module.

### New Methods for Messenger Channels:

* [`packages/auto-xdm/src/info.ts`](diffhunk://#diff-58ef5808f0a1f992156be7f77b8904ae2ecf286d7cec50814d4bd99cd7cde9efL4-R16): Added new methods `channels`, `consensusChannels`, and `domainChannels` to query messenger channels using `ApiPromise` and `Codec`.
* [`packages/auto-xdm/src/messenger.ts`](diffhunk://#diff-32fcd7a371353fa37e93f3dd03bcc7756fc8f5d0ea7c37aca75e90e231f73787R1-R11): Introduced methods `initiateChannel` and `closeChannel` to handle messenger channel operations.