### PR TITLE
Fix: createDomainsChainIdType falsy assumption on domainId 0

### DIFF
--- a/packages/auto-utils/src/utils/createType.ts
+++ b/packages/auto-utils/src/utils/createType.ts
@@ -9,7 +9,7 @@ export const createDomainsChainIdType = (api: ApiPromise, domainId?: string | nu
   createType(
     api.registry,
     'SpDomainsChainId',
-    domainId ? { Domain: domainId } : { Consensus: null },
+    domainId !== undefined ? { Domain: domainId } : { Consensus: null },
   )
 
 export const createAccountId20Type = (api: ApiPromise, address: string) =>


### PR DESCRIPTION
## Fix: createDomainsChainIdType falsy assumption on domainId 0

This pull request includes a small change to the `createDomainsChainIdType` function in the `packages/auto-utils/src/utils/createType.ts` file. The change ensures that the `domainId` parameter is explicitly checked for `undefined` before setting the `Domain` or `Consensus` value.

* [`packages/auto-utils/src/utils/createType.ts`](diffhunk://#diff-4266d5cd997fdc7490f0ca3eff463b94288a673fe7d6759fc7a47afc7eed2032L12-R12): Modified the `createDomainsChainIdType` function to check if `domainId` is not `undefined` before assigning `{ Domain: domainId }` or `{ Consensus: null }`.