### PR TITLE
Fix rpc response

### DIFF
--- a/packages/rpc/src/models/common.ts
+++ b/packages/rpc/src/models/common.ts
@@ -11,6 +11,8 @@ export const messageSchema = z.object({
 
 export type Message = z.infer<typeof messageSchema>
 
+export type MessageQuery = Omit<Message, 'id'> & { id?: number }
+
 export type MessageResponse = {
   jsonrpc: string
   error?: {
@@ -22,4 +24,4 @@ export type MessageResponse = {
   id: number
 }
 
-export type MessageQuery = Omit<Message, 'id'> & { id?: number }
+export type MessageResponseQuery = Omit<MessageResponse, 'id'> & { id?: number }

--- a/packages/rpc/src/models/common.ts
+++ b/packages/rpc/src/models/common.ts
@@ -24,4 +24,7 @@ export type MessageResponse = {
   id: number
 }
 
-export type MessageResponseQuery = Omit<MessageResponse, 'id'> & { id?: number }
+export type MessageResponseQuery = Omit<MessageResponse, 'id' | 'jsonrpc'> & {
+  id?: number
+  jsonrpc?: string
+}

--- a/packages/rpc/src/rpc/client.ts
+++ b/packages/rpc/src/rpc/client.ts
@@ -4,7 +4,7 @@ import { Message, MessageQuery, MessageResponseQuery } from '../models/common'
 import { parseData } from '../utils/websocket'
 import { createWsClient } from '../ws/client'
 import { WsClient } from '../ws/types'
-import { RpcCallback } from './types'
+import { ClientRPCListener } from './types'
 
 export const createRpcClient = ({
   endpoint,
@@ -37,7 +37,7 @@ export const createRpcClient = ({
       connection({ type: 'utf8', utf8Data: JSON.stringify(message) })
   }
 
-  let onMessageCallbacks: RpcCallback[] = []
+  let onMessageCallbacks: ClientRPCListener[] = []
 
   const send = async (message: MessageQuery) => {
     const id = message.id ?? Math.floor(Math.random() * 65546)
@@ -60,11 +60,11 @@ export const createRpcClient = ({
     })
   }
 
-  const on = (callback: (event: Message) => void) => {
+  const on = (callback: ClientRPCListener) => {
     onMessageCallbacks.push(callback)
   }
 
-  const off = (callback: (event: Message) => void) => {
+  const off = (callback: ClientRPCListener) => {
     onMessageCallbacks = onMessageCallbacks.filter((cb) => cb !== callback)
   }
 
@@ -72,7 +72,7 @@ export const createRpcClient = ({
     const rpcResponder = connectionMessager(responder)
     try {
       const messageObj = JSON.parse(parseData(message))
-      onMessageCallbacks.forEach((callback) => callback(messageObj, rpcResponder))
+      onMessageCallbacks.forEach((callback) => callback(messageObj))
     } catch (error) {
       callbacks.onWrongMessage?.(rpcResponder)
     }

--- a/packages/rpc/src/rpc/client.ts
+++ b/packages/rpc/src/rpc/client.ts
@@ -1,6 +1,6 @@
 import Websocket from 'websocket'
 import { ClientRPC } from '../models/client'
-import { Message, MessageQuery } from '../models/common'
+import { Message, MessageQuery, MessageResponseQuery } from '../models/common'
 import { parseData } from '../utils/websocket'
 import { createWsClient } from '../ws/client'
 import { WsClient } from '../ws/types'
@@ -17,7 +17,7 @@ export const createRpcClient = ({
     onReconnection?: () => void
     onError?: (error: Error) => void
     onClose?: (event: Websocket.ICloseEvent) => void
-    onWrongMessage?: (responder: (message: string) => void) => void
+    onWrongMessage?: (responder: (message: MessageResponseQuery) => void) => void
   }
   reconnectInterval?: number | null
 }): ClientRPC => {
@@ -33,7 +33,8 @@ export const createRpcClient = ({
   })
 
   const connectionMessager = (connection: (message: Websocket.Message) => void) => {
-    return (message: string) => connection({ type: 'utf8', utf8Data: message })
+    return (message: MessageResponseQuery) =>
+      connection({ type: 'utf8', utf8Data: JSON.stringify(message) })
   }
 
   let onMessageCallbacks: RpcCallback[] = []

--- a/packages/rpc/src/rpc/server.ts
+++ b/packages/rpc/src/rpc/server.ts
@@ -1,4 +1,4 @@
-import { Message, MessageQuery, MessageResponse, messageSchema } from '../models/common'
+import { MessageResponse, MessageResponseQuery, messageSchema } from '../models/common'
 import { WsServer } from '../models/server'
 import { safeParseJson } from '../utils/json'
 import { parseMessage } from '../utils/websocket'
@@ -37,6 +37,10 @@ export const createRpcServer = ({
         return { ...message, id: parsedMessage.data.id }
       }
 
+      const sendMessageWithId = (message: MessageResponseQuery) => {
+        connection.sendUTF(JSON.stringify(wrapResponse(message)))
+      }
+
       // Find the handler for the message
       const handler = handlers.find(
         (handler) => parsedMessage.data.method === handler.method,
@@ -54,11 +58,11 @@ export const createRpcServer = ({
       }
 
       // Handle the message and send the response if it exists
-      const response = handler(parsedMessage.data, (message) => {
-        connection.sendUTF(JSON.stringify(message))
+      const response = handler(parsedMessage.data, (message: MessageResponseQuery) => {
+        sendMessageWithId(message)
       })
       if (parsedMessage.data.id && response) {
-        connection.sendUTF(JSON.stringify(response))
+        sendMessageWithId(response)
       }
     } catch (error) {
       connection.sendUTF(JSON.stringify({ error: 'Unknown error' }))

--- a/packages/rpc/src/rpc/types.ts
+++ b/packages/rpc/src/rpc/types.ts
@@ -1,8 +1,8 @@
-import { Message, MessageResponse } from '../models/common'
+import { Message, MessageResponse, MessageResponseQuery } from '../models/common'
 
 type RpcResponse = MessageResponse | void
 
-export type RpcClientResponder = (message: string) => void
+export type RpcClientResponder = (message: MessageResponseQuery) => void
 
 export type RpcCallback = (
   message: Message,

--- a/packages/rpc/src/rpc/types.ts
+++ b/packages/rpc/src/rpc/types.ts
@@ -1,12 +1,15 @@
-import { Message, MessageResponse, MessageResponseQuery } from '../models/common'
+import { connection } from 'websocket'
+import { Message, MessageResponseQuery } from '../models/common'
 
-type RpcResponse = MessageResponse | void
+type RpcResponse = MessageResponseQuery | void | Promise<MessageResponseQuery | void>
 
 export type RpcClientResponder = (message: MessageResponseQuery) => void
 
+export type ClientRPCListener = (message: Message) => void
+
 export type RpcCallback = (
   message: Message,
-  responder: RpcClientResponder,
+  params: { connection: connection; messageId?: number },
 ) => RpcResponse | undefined
 
 export type RpcHandler = {


### PR DESCRIPTION
The controller for rpc responses expected a `string` where it should receive a `MessageResponseQuery`

Also I updated the type `MessageResponseQuery` for easing the devEx