### PR TITLE
Fixing/enhancing RPC server

### DIFF
--- a/packages/rpc/__test__/rpc/index.spec.ts
+++ b/packages/rpc/__test__/rpc/index.spec.ts
@@ -41,8 +41,8 @@ describe('RPC', () => {
 
     rpcServer.addRpcHandler({
       method: 'test',
-      handler: (msg) =>
-        msg.id
+      handler: (msg, { messageId }) =>
+        messageId
           ? {
               jsonrpc: '2.0',
               result: 'success',
@@ -71,8 +71,8 @@ describe('RPC', () => {
   it('should handle messages with missing parameters', async () => {
     rpcServer.addRpcHandler({
       method: 'test',
-      handler: (msg) => {
-        return msg.id ? { jsonrpc: '2.0', id: msg.id, result: 'success' } : undefined
+      handler: (_, { messageId }) => {
+        return messageId ? { jsonrpc: '2.0', id: messageId, result: 'success' } : undefined
       },
     })
 

--- a/packages/rpc/src/models/server.ts
+++ b/packages/rpc/src/models/server.ts
@@ -4,6 +4,7 @@ export interface WsServer {
   broadcastMessage: (message: Websocket.Message) => void
   onMessage: (cb: WsMessageCallback) => void
   close: () => void
+  listen: (port: number, cb?: () => void) => void
 }
 
 export type WsMessageCallback = (

--- a/packages/rpc/src/rpc/server.ts
+++ b/packages/rpc/src/rpc/server.ts
@@ -18,6 +18,7 @@ export const createRpcServer = ({
 }) => {
   const wsServer = isWsServer(server) ? server : createWsServer(server)
   const handlers = initialHandlers ?? []
+
   wsServer.onMessage(async (msg, { connection }) => {
     try {
       const utf8Data = parseMessage(msg)
@@ -58,7 +59,7 @@ export const createRpcServer = ({
       }
 
       // Handle the message and send the response if it exists
-      const response = await handler(parsedMessage.data, {
+      const response = await handler(parsedMessage.data.params, {
         connection,
         messageId: parsedMessage.data.id,
       })
@@ -79,8 +80,13 @@ export const createRpcServer = ({
     return wsServer.close()
   }
 
+  const listen = (port: number, cb?: () => void) => {
+    return wsServer.listen(port, cb)
+  }
+
   return {
     addRpcHandler,
     close,
+    listen,
   }
 }

--- a/packages/rpc/src/rpc/server.ts
+++ b/packages/rpc/src/rpc/server.ts
@@ -1,4 +1,4 @@
-import { MessageResponse, MessageResponseQuery, messageSchema } from '../models/common'
+import { MessageResponseQuery, messageSchema } from '../models/common'
 import { WsServer } from '../models/server'
 import { safeParseJson } from '../utils/json'
 import { parseMessage } from '../utils/websocket'

--- a/packages/rpc/src/rpc/types.ts
+++ b/packages/rpc/src/rpc/types.ts
@@ -8,8 +8,8 @@ export type RpcClientResponder = (message: MessageResponseQuery) => void
 export type ClientRPCListener = (message: Message) => void
 
 export type RpcCallback = (
-  message: Message,
-  params: { connection: connection; messageId?: number },
+  params: Message['params'],
+  rpcParams: { connection: connection; messageId?: number },
 ) => RpcResponse | undefined
 
 export type RpcHandler = {

--- a/packages/rpc/src/ws/server.ts
+++ b/packages/rpc/src/ws/server.ts
@@ -17,8 +17,9 @@ export const createWsServer = ({
 }): WsServer => {
   const messageCallbacks: WsMessageCallback[] = []
 
+  const internalHttpServer = http.createServer(httpServer)
   const ws = new Websocket.server({
-    httpServer: http.createServer(httpServer),
+    httpServer: internalHttpServer,
     autoAcceptConnections: false,
   })
 
@@ -64,9 +65,14 @@ export const createWsServer = ({
     httpServer.closeAllConnections()
   }
 
+  const listen = (port: number, cb?: () => void) => {
+    internalHttpServer.listen(port, cb)
+  }
+
   return {
     broadcastMessage,
     onMessage,
     close,
+    listen,
   }
 }


### PR DESCRIPTION
- RPC Callbacks were passing the whole message rather than the expect `params` field
- The server listening was a bit more tricky than expected so I added a new method in rpc for listening