### PR TITLE
Add notifications support to Type-Safe RPC

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "npmClient": "yarn"
 }

--- a/packages/asynchronous/package.json
+++ b/packages/asynchronous/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/asynchronous",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/auto-consensus/package.json
+++ b/packages/auto-consensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-consensus",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-utils": "^1.4.8"
+    "@autonomys/auto-utils": "^1.4.10"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/auto-dag-data/package.json
+++ b/packages/auto-dag-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-dag-data",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.4.8",
+    "@autonomys/asynchronous": "^1.4.10",
     "@ipld/dag-pb": "^4.1.3",
     "@peculiar/webcrypto": "^1.5.0",
     "@webbuf/blake3": "^3.0.26",

--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-drive",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,9 +42,9 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.4.8",
-    "@autonomys/auto-dag-data": "^1.4.8",
-    "@autonomys/auto-utils": "^1.4.8",
+    "@autonomys/asynchronous": "^1.4.10",
+    "@autonomys/auto-dag-data": "^1.4.10",
+    "@autonomys/auto-utils": "^1.4.10",
     "blockstore-core": "^5.0.2",
     "jszip": "^3.10.1",
     "mime-types": "^3.0.0",

--- a/packages/auto-utils/package.json
+++ b/packages/auto-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-utils",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/packages/auto-xdm/package.json
+++ b/packages/auto-xdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-xdm",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,8 +25,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-consensus": "^1.4.8",
-    "@autonomys/auto-utils": "^1.4.8"
+    "@autonomys/auto-consensus": "^1.4.10",
+    "@autonomys/auto-utils": "^1.4.10"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/file-caching/package.json
+++ b/packages/file-caching/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/file-caching",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -45,9 +45,9 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.4.8",
-    "@autonomys/auto-dag-data": "^1.4.8",
-    "@autonomys/auto-utils": "^1.4.8",
+    "@autonomys/asynchronous": "^1.4.10",
+    "@autonomys/auto-dag-data": "^1.4.10",
+    "@autonomys/auto-utils": "^1.4.10",
     "@keyvhq/sqlite": "^2.1.7",
     "cache-manager": "^6.4.1",
     "jszip": "^3.10.1",

--- a/packages/rpc/__test__/rpc/typed.spec.ts
+++ b/packages/rpc/__test__/rpc/typed.spec.ts
@@ -1,4 +1,5 @@
 import http from 'http'
+import { connection } from 'websocket'
 import { z } from 'zod'
 import { createRpcClient, createWsClient, createWsServer } from '../../src'
 import { createApiDefinition } from '../../src/rpc/api/definition'
@@ -7,18 +8,27 @@ import { createBaseHttpServer, TEST_PORT } from '../utils'
 
 describe('rpc/definition', () => {
   let httpServer: http.Server
+  let connection: connection
+
   const { createClient, createServer } = createApiDefinition({
-    test: {
-      params: z.object({ name: z.string() }),
-      returns: z.object({ name: z.string() }),
+    methods: {
+      test: {
+        params: z.object({ name: z.string() }),
+        returns: z.object({ name: z.string() }),
+      },
+      internal_error: {
+        params: z.object({ name: z.string() }),
+        returns: z.object({ name: z.string() }),
+      },
+      rpc_error: {
+        params: z.void(),
+        returns: z.void(),
+      },
     },
-    internal_error: {
-      params: z.object({ name: z.string() }),
-      returns: z.object({ name: z.string() }),
-    },
-    rpc_error: {
-      params: z.void(),
-      returns: z.void(),
+    notifications: {
+      test: {
+        content: z.object({ name: z.string() }),
+      },
     },
   })
   let client: ReturnType<typeof createClient>
@@ -29,7 +39,10 @@ describe('rpc/definition', () => {
 
     server = createServer(
       {
-        test: (params) => {
+        test: (params, { connection: _connection }) => {
+          // Workaround to get the connection object
+          // for the notification test
+          connection = _connection
           return {
             name: params.name,
           }
@@ -133,5 +146,18 @@ describe('rpc/definition', () => {
     })
 
     client.close()
+  })
+
+  it('should send notifications and receive them', async () => {
+    const mock = jest.fn()
+
+    client.onNotification('test', (params) => {
+      mock(params.name)
+    })
+
+    server.notificationClient.test(connection, { name: 'test' })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(mock.mock.calls[0][0]).toEqual('test')
   })
 })

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/rpc",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/autonomys/auto-sdk"

--- a/packages/rpc/src/rpc/api/definition.ts
+++ b/packages/rpc/src/rpc/api/definition.ts
@@ -7,6 +7,7 @@ import {
   ApiClientType,
   ApiDefinition,
   ApiServerHandlers,
+  ApiServerNotifications,
   DefinitionTypeOutput,
   isZodType,
 } from './typing'
@@ -85,7 +86,7 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
           }) as TypedRpcNotificationHandler<DefinitionTypeOutput<typeof handler.content>>,
         ]
       }),
-    )
+    ) as ApiServerNotifications<S>
 
     for (const [method, internalHandler] of Object.entries(handlers)) {
       const handler = async (

--- a/packages/rpc/src/rpc/api/definition.ts
+++ b/packages/rpc/src/rpc/api/definition.ts
@@ -1,10 +1,21 @@
+import Websocket from 'websocket'
+import { PromiseOr } from '../../utils/types'
 import { createRpcClient } from '../client'
 import { createRpcServer } from '../server'
+import {
+  Message,
+  MessageQuery,
+  RpcParams,
+  TypedRpcCallback,
+  TypedRpcNotificationHandler,
+  TypedRpcParams,
+} from '../types'
 import { RpcError } from '../utils'
 import {
   ApiClientType,
   ApiDefinition,
   ApiServerHandlers,
+  ApiServerNotifications,
   DefinitionTypeOutput,
   isZodType,
 } from './typing'
@@ -12,10 +23,19 @@ import {
 export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S) => {
   const createClient = <Client extends ApiClientType<S>>(
     clientParams: Parameters<typeof createRpcClient>[0],
-  ): { api: Client; close: () => void } => {
+  ): {
+    api: Client
+    close: () => void
+    onNotification: (
+      notificationName: keyof S['notifications'],
+      handler: (
+        params: DefinitionTypeOutput<S['notifications'][keyof S['notifications']]['content']>,
+      ) => void,
+    ) => void
+  } => {
     const client = createRpcClient(clientParams)
 
-    const apiMethods = Object.entries(serverDefinition).map(([method, handler]) => {
+    const apiMethods = Object.entries(serverDefinition.methods).map(([method, handler]) => {
       return [
         method,
         async (params: Parameters<DefinitionTypeOutput<typeof handler.params>>[0]) => {
@@ -34,9 +54,21 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
       ]
     })
 
+    const onNotification = <T extends keyof S['notifications']>(
+      notificationName: T,
+      handler: (params: DefinitionTypeOutput<S['notifications'][T]['content']>) => void,
+    ) => {
+      client.on((message: Message) => {
+        if (message.method === notificationName) {
+          handler(message.params)
+        }
+      })
+    }
+
     return {
       api: Object.fromEntries(apiMethods) as Client,
       close: client.close,
+      onNotification,
     }
   }
 
@@ -49,14 +81,14 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
     for (const [method, internalHandler] of Object.entries(handlers)) {
       const handler = async (
         params: Parameters<Handlers[keyof Handlers]>[0],
-        rpcParams: Parameters<Handlers[keyof Handlers]>[1],
+        rpcParams: TypedRpcParams<S>,
       ) => {
         if (!rpcParams.messageId) {
           throw new RpcError('Message ID is required', RpcError.Code.InvalidRequest)
         }
 
-        if (isZodType(serverDefinition[method].params)) {
-          const result = serverDefinition[method].params.safeParse(params)
+        if (isZodType(serverDefinition.methods[method].params)) {
+          const result = serverDefinition.methods[method].params.safeParse(params)
           if (!result.success) {
             throw new RpcError(result.error.message, RpcError.Code.InvalidParams)
           }
@@ -77,7 +109,31 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
       })
     }
 
-    return server
+    const sendMessage = (connection: Websocket.connection, message: MessageQuery) => {
+      connection.send(JSON.stringify(message))
+    }
+
+    const notificationClient = Object.entries(serverDefinition.notifications).map(
+      ([notificationName, handler]) => {
+        return [
+          notificationName,
+          ((
+            connection: Websocket.connection,
+            params: Parameters<DefinitionTypeOutput<typeof handler.content>>[0],
+          ) => {
+            sendMessage(connection, {
+              jsonrpc: '2.0',
+              method: notificationName,
+              params,
+            })
+          }) as TypedRpcNotificationHandler<DefinitionTypeOutput<typeof handler.content>>,
+        ]
+      },
+    )
+    return {
+      ...server,
+      notificationClient: Object.fromEntries(notificationClient) as ApiServerNotifications<S>,
+    }
   }
 
   return { createClient, createServer }

--- a/packages/rpc/src/rpc/server.ts
+++ b/packages/rpc/src/rpc/server.ts
@@ -95,9 +95,7 @@ export const createRpcServer = ({
     }
   })
 
-  const addRpcHandler = <I, O extends RpcResponse, S extends ApiDefinition>(
-    handler: TypedRPCHandler<I, O, S>,
-  ) => {
+  const addRpcHandler = <I, O extends RpcResponse>(handler: RpcHandler<I, O>) => {
     handlers.push(handler)
   }
 

--- a/packages/rpc/src/rpc/server.ts
+++ b/packages/rpc/src/rpc/server.ts
@@ -3,12 +3,14 @@ import { safeParseJson } from '../utils/json'
 import { parseMessage } from '../utils/websocket'
 import { WsServer } from '../ws'
 import { createWsServer } from '../ws/server'
+import { ApiDefinition } from './api'
 import {
   MessageResponseQuery,
   messageSchema,
   RpcHandler,
   RpcHandlerList,
   RpcResponse,
+  TypedRPCHandler,
 } from './types'
 import { errorResponse, RpcError, wrapResponse } from './utils'
 
@@ -93,7 +95,9 @@ export const createRpcServer = ({
     }
   })
 
-  const addRpcHandler = <I, O extends RpcResponse>(handler: RpcHandler<I, O>) => {
+  const addRpcHandler = <I, O extends RpcResponse, S extends ApiDefinition>(
+    handler: TypedRPCHandler<I, O, S>,
+  ) => {
     handlers.push(handler)
   }
 

--- a/packages/rpc/src/rpc/types.ts
+++ b/packages/rpc/src/rpc/types.ts
@@ -76,7 +76,7 @@ export type RpcHandler<I, O extends RpcResponse> = {
 export type TypedRpcParams<S extends ApiDefinition> = {
   connection: connection
   messageId?: number
-  notificationService?: ApiServerNotifications<S>
+  notificationClient: ApiServerNotifications<S>
 }
 
 export type TypedRpcCallback<I, O extends RpcResponse, S extends ApiDefinition> = (
@@ -92,3 +92,5 @@ export type TypedRPCHandler<I, O extends RpcResponse, S extends ApiDefinition> =
 export type TypedRpcNotificationHandler<I> = (connection: connection, params: I) => void
 
 export type RpcHandlerList = RpcHandler<any, RpcResponse>[]
+
+export type TypedRpcHandlerList<S extends ApiDefinition> = TypedRPCHandler<any, RpcResponse, S>[]

--- a/packages/rpc/src/rpc/types.ts
+++ b/packages/rpc/src/rpc/types.ts
@@ -1,6 +1,7 @@
 import { connection } from 'websocket'
 import { z } from 'zod'
 import { PromiseOr } from '../utils/types'
+import { ApiDefinition, ApiServerNotifications } from './api'
 
 export type ClientRPC = {
   send: (message: MessageQuery) => Promise<MessageResponse>
@@ -57,14 +58,37 @@ export type RpcClientResponder = (message: MessageResponseQuery) => void
 
 export type ClientRPCListener = ((message: Message) => void) | ((message: MessageResponse) => void)
 
+export type RpcParams = {
+  connection: connection
+  messageId?: number
+}
+
 export type RpcCallback<I, O extends RpcResponse> = (
   params: I,
-  rpcParams: { connection: connection; messageId?: number },
+  rpcParams: RpcParams,
 ) => O | undefined
 
 export type RpcHandler<I, O extends RpcResponse> = {
   method: string
   handler: RpcCallback<I, O>
 }
+
+export type TypedRpcParams<S extends ApiDefinition> = {
+  connection: connection
+  messageId?: number
+  notificationService?: ApiServerNotifications<S>
+}
+
+export type TypedRpcCallback<I, O extends RpcResponse, S extends ApiDefinition> = (
+  params: I,
+  rpcParams: TypedRpcParams<S>,
+) => O | undefined
+
+export type TypedRPCHandler<I, O extends RpcResponse, S extends ApiDefinition> = {
+  method: string
+  handler: TypedRpcCallback<I, O, S>
+}
+
+export type TypedRpcNotificationHandler<I> = (connection: connection, params: I) => void
 
 export type RpcHandlerList = RpcHandler<any, RpcResponse>[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@autonomys/asynchronous@npm:^1.4.8, @autonomys/asynchronous@workspace:packages/asynchronous":
+"@autonomys/asynchronous@npm:^1.4.10, @autonomys/asynchronous@workspace:packages/asynchronous":
   version: 0.0.0-use.local
   resolution: "@autonomys/asynchronous@workspace:packages/asynchronous"
   dependencies:
@@ -36,11 +36,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-consensus@npm:^1.4.8, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
+"@autonomys/auto-consensus@npm:^1.4.10, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-consensus@workspace:packages/auto-consensus"
   dependencies:
-    "@autonomys/auto-utils": "npm:^1.4.8"
+    "@autonomys/auto-utils": "npm:^1.4.10"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.23.0"
     jest: "npm:^29.7.0"
@@ -50,11 +50,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-dag-data@npm:^1.4.8, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
+"@autonomys/auto-dag-data@npm:^1.4.10, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-dag-data@workspace:packages/auto-dag-data"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.4.8"
+    "@autonomys/asynchronous": "npm:^1.4.10"
     "@ipld/dag-pb": "npm:^4.1.3"
     "@peculiar/webcrypto": "npm:^1.5.0"
     "@types/jest": "npm:^29.5.14"
@@ -78,9 +78,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-drive@workspace:packages/auto-drive"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.4.8"
-    "@autonomys/auto-dag-data": "npm:^1.4.8"
-    "@autonomys/auto-utils": "npm:^1.4.8"
+    "@autonomys/asynchronous": "npm:^1.4.10"
+    "@autonomys/auto-dag-data": "npm:^1.4.10"
+    "@autonomys/auto-utils": "npm:^1.4.10"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"
     "@rollup/plugin-json": "npm:^6.1.0"
@@ -114,7 +114,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-utils@npm:^1.4.8, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
+"@autonomys/auto-utils@npm:^1.4.10, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-utils@workspace:packages/auto-utils"
   dependencies:
@@ -137,8 +137,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-xdm@workspace:packages/auto-xdm"
   dependencies:
-    "@autonomys/auto-consensus": "npm:^1.4.8"
-    "@autonomys/auto-utils": "npm:^1.4.8"
+    "@autonomys/auto-consensus": "npm:^1.4.10"
+    "@autonomys/auto-utils": "npm:^1.4.10"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.23.0"
     jest: "npm:^29.7.0"
@@ -152,9 +152,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/file-caching@workspace:packages/file-caching"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.4.8"
-    "@autonomys/auto-dag-data": "npm:^1.4.8"
-    "@autonomys/auto-utils": "npm:^1.4.8"
+    "@autonomys/asynchronous": "npm:^1.4.10"
+    "@autonomys/auto-dag-data": "npm:^1.4.10"
+    "@autonomys/auto-utils": "npm:^1.4.10"
     "@keyvhq/sqlite": "npm:^2.1.7"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"


### PR DESCRIPTION
In addition to the Message (client request + server response) rpc feature server should be able to send messages to the client for enabling mechanism like subscription to events.

This wasn't support before and this PR enables server to send notifications