### PR TITLE
fix: caching policy

### DIFF
--- a/packages/utility/file-caching/src/fileCache.ts
+++ b/packages/utility/file-caching/src/fileCache.ts
@@ -21,13 +21,13 @@ export const createFileCache = (config: BaseCacheConfig) => {
       filePath = path.join(filePath, `${head.slice(-CHARS_PER_PARTITION)}/`)
       head = head.slice(0, -CHARS_PER_PARTITION)
     }
-    filePath = path.join(filePath, head)
-
+    filePath = path.join(filePath, head, cid)
     return path.join(config.cacheDir, filePath)
   }
 
   const filepathCache = createCache({
     stores: config.stores,
+    nonBlocking: false,
   })
 
   const deserialize = (data: Omit<FileResponse, 'data'> | null) => {


### PR DESCRIPTION
Using nonBlocking policy was making that no file was stored in sqlite cache leading to cache loss when service reboots. 

Additionally, I was generating incorrectly the path for the file to be stored though it wasn't causing problems due to the partiotioning of folders. 