### PR TITLE
Fix auto-mcp-server package usage

### DIFF
--- a/packages/auto-mcp-servers/README.md
+++ b/packages/auto-mcp-servers/README.md
@@ -21,22 +21,14 @@ More servers and tools will be coming soon!
 ### With Claude Desktop
 
 1. Install Claude Desktop
-2. Install the Auto Drive server globally:
-
-```bash
-npm install -g @autonomys/auto-mcp-servers
-# or
-yarn global add @autonomys/auto-mcp-servers
-```
-
-3. Edit your `claude_desktop_config.json` file:
+2. Edit your `claude_desktop_config.json` file:
 
 ```json
 {
   "mcpServers": {
     "auto-drive": {
       "command": "npx",
-      "args": ["auto-drive-server"],
+      "args": ["-y", "@autonomys/auto-mcp-servers", "auto-drive"],
       "env": { "AUTO_DRIVE_API_KEY": "your-api-key" }
     }
   }

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-mcp-servers",
   "packageManager": "yarn@4.7.0",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.2",
   "description": "Autonomys Network MCP servers",
   "repository": {
     "type": "git",
@@ -18,10 +18,12 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
+    "auto-mcp-servers": "./dist/bin/main.js",
     "auto-drive-server": "./dist/bin/auto-drive.js"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "prepublishOnly": "npm run build && chmod +x ./dist/bin/*.js"
   },
   "keywords": [
     "mcp",

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -18,8 +18,8 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "auto-mcp-servers": "./dist/bin/main.js",
-    "auto-drive-server": "./dist/bin/auto-drive.js"
+    "auto-drive-server": "./dist/bin/auto-drive.js",
+    "auto-mcp-servers": "./dist/bin/main.js"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/auto-mcp-servers/src/bin/main.ts
+++ b/packages/auto-mcp-servers/src/bin/main.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { autoDriveServer } from '../auto-drive/index.js'
+
+const showHelp = () => {
+  console.log(`
+Usage: auto-mcp-servers [server-name]
+
+Available servers:
+  auto-drive    Start the Auto Drive MCP server
+
+Environment variables:
+  For Auto Drive server:
+    AUTO_DRIVE_API_KEY     API key for Auto Drive (required)
+    NETWORK                'mainnet' (default) or 'taurus'
+    ENCRYPTION_PASSWORD    Password for encryption (optional)
+  `)
+  process.exit(1)
+}
+
+const main = async () => {
+  const serverName = process.argv[2] || 'auto-drive'
+  const transport = new StdioServerTransport()
+
+  switch (serverName) {
+    case 'auto-drive':
+      await autoDriveServer.connect(transport)
+      break
+    case 'help':
+    case '--help':
+    case '-h':
+      showHelp()
+      break
+    default:
+      console.error(`Unknown server: ${serverName}`)
+      showHelp()
+      break
+  }
+}
+
+main().catch((error) => {
+  console.error(`Failed to start MCP server:`, error)
+  process.exit(1)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,7 @@ __metadata:
     zod: "npm:^3.24.2"
   bin:
     auto-drive-server: ./dist/bin/auto-drive.js
+    auto-mcp-servers: ./dist/bin/main.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR fixes the `@autonomys/auto-mcp-servers` package by implementing a multi-server architecture with a unified entry point, allowing users to direct to the desired underlying mcp-server.

## Changes

- **Multi-server architecture**: Added a main entry point (`bin/main.ts`) that can dispatch to different MCP servers
- **Improved binaries**: Updated package.json with multiple bin entries for both direct server execution and the main dispatcher
- **Build process**: Added prepublishOnly script to ensure binaries are properly executable after build
- **Documentation**: Updated README with simplified installation instructions using npx

## Benefits

- Users can now run servers either directly (`auto-drive-server`) or through the main entry point (`auto-mcp-servers auto-drive`)
- Better Claude Desktop and other desktop client integration with simplified configuration
- More maintainable structure for adding future MCP servers

## Testing

Tested with Claude Desktop using the new configuration:

```json
{
  "mcpServers": {
    "auto-drive": {
      "command": "npx",
      "args": ["-y", "@autonomys/auto-mcp-servers", "auto-drive"],
      "env": { "AUTO_DRIVE_API_KEY": "your-api-key" }
    }
  }
}
```