### PR TITLE
Feature: Add download object and search object tools to auto-drive mcp

### DIFF
--- a/packages/auto-mcp-servers/README.md
+++ b/packages/auto-mcp-servers/README.md
@@ -12,7 +12,9 @@ The Auto Drive server exposes functionality from the `@autonomys/auto-drive` pac
 
 The Auto Drive server provides the following tools:
 
-- `uploadObject`: Upload an object to the Autonomys network.
+- `upload-object`: Upload an object (as JSON data) to the Autonomys network.
+- `download-object`: Download a text-based object (`text/*` or `application/json`) from the Autonomys network using its CID.
+- `search-objects`: Search for objects on the Autonomys network by name or CID fragment. Returns a JSON object containing an array of results, each including the object's name, CID, type, size, and mimeType (for files).
 
 More servers and tools will be coming soon!
 
@@ -29,7 +31,11 @@ More servers and tools will be coming soon!
     "auto-drive": {
       "command": "npx",
       "args": ["-y", "@autonomys/auto-mcp-servers", "auto-drive"],
-      "env": { "AUTO_DRIVE_API_KEY": "your-api-key" }
+      "env": {
+        "AUTO_DRIVE_API_KEY": "your-api-key",
+        "ENCRYPTION_PASSWORD": "my-password (optional)",
+        "NETWORK": "mainnet or taurus (optional, defaults to mainnet)"
+      }
     }
   }
 }

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-mcp-servers",
   "packageManager": "yarn@4.7.0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Autonomys Network MCP servers",
   "repository": {
     "type": "git",

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-mcp-servers",
   "packageManager": "yarn@4.7.0",
-  "version": "0.1.1-alpha.2",
+  "version": "0.1.1",
   "description": "Autonomys Network MCP servers",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build && chmod +x ./dist/bin/*.js"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "mcp",

--- a/packages/auto-mcp-servers/src/auto-drive/handlers.ts
+++ b/packages/auto-mcp-servers/src/auto-drive/handlers.ts
@@ -1,0 +1,105 @@
+import { createAutoDriveApi, UploadFileOptions } from '@autonomys/auto-drive'
+
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+
+export const createAutoDriveHandlers = (
+  apiKey: string,
+  network: 'taurus' | 'mainnet',
+  encryptionPassword?: string,
+) => {
+  const autoDriveApi = createAutoDriveApi({ apiKey, network })
+  const uploadOptions: UploadFileOptions | undefined = encryptionPassword
+    ? { password: encryptionPassword }
+    : undefined
+
+  return {
+    uploadObjectHandler: async ({
+      filename,
+      data,
+    }: {
+      filename: string
+      data: Record<string, any>
+    }): Promise<CallToolResult> => {
+      const cid = await autoDriveApi.uploadObjectAsJSON({ data }, filename, uploadOptions)
+      return { content: [{ type: 'text', text: `Object uploaded successfully with ${cid}` }] }
+    },
+    downloadObjectHandler: async ({ cid }: { cid: string }): Promise<CallToolResult> => {
+      try {
+        // Get object summary to determine type and metadata
+        const summaries = await autoDriveApi.searchByNameOrCID(cid)
+        if (!summaries || summaries.length === 0) {
+          throw new Error(`Object not found for CID: ${cid}`)
+        }
+        const summary = summaries[0]
+
+        // Handle folders
+        if (summary.type === 'folder') {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Error: CID ${cid} points to a folder, which cannot be downloaded directly with this tool.`,
+              },
+            ],
+          }
+        }
+
+        const mimeType = summary.mimeType || 'application/octet-stream'
+        const filename = summary.name || `download-${cid}`
+
+        // Handle only text-based types
+        if (mimeType.startsWith('text/') || mimeType === 'application/json') {
+          const stream = await autoDriveApi.downloadFile(cid, encryptionPassword)
+          let fileBuffer = Buffer.alloc(0)
+          for await (const chunk of stream) {
+            fileBuffer = Buffer.concat([fileBuffer, chunk])
+          }
+          try {
+            const text = fileBuffer.toString('utf-8')
+            return {
+              content: [{ type: 'text', text }],
+            }
+          } catch (e) {
+            console.error(`Failed to decode text content for ${filename} (${mimeType})`, e)
+            return {
+              isError: true,
+              content: [
+                {
+                  type: 'text',
+                  text: `Error: Failed to decode file content for ${filename} as UTF-8 text.`,
+                },
+              ],
+            }
+          }
+        }
+
+        // For all other types, return an error
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Error: File type \'${mimeType}\' is not supported for direct download in this client. Only text/* and application/json are supported.`,
+            },
+          ],
+        }
+      } catch (error: any) {
+        console.error(`Failed to download object with CID ${cid}:`, error)
+        const errorMessage = error.message || 'Unknown error occurred during download.'
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Error downloading object: ${errorMessage}` }],
+        }
+      }
+    },
+    searchObjectsHandler: async ({ query }: { query: string }): Promise<CallToolResult> => {
+      const summaries = await autoDriveApi.searchByNameOrCID(query)
+      return {
+        content: [
+          { type: 'text', text: `Objects found: ${summaries.map((s) => s.name).join(', ')}` },
+        ],
+      }
+    },
+  }
+}

--- a/packages/auto-mcp-servers/src/auto-drive/handlers.ts
+++ b/packages/auto-mcp-servers/src/auto-drive/handlers.ts
@@ -95,10 +95,15 @@ export const createAutoDriveHandlers = (
     },
     searchObjectsHandler: async ({ query }: { query: string }): Promise<CallToolResult> => {
       const summaries = await autoDriveApi.searchByNameOrCID(query)
+      const results = summaries.map((s) => ({
+        name: s.name,
+        cid: s.headCid,
+        type: s.type,
+        size: s.size,
+        ...(s.type === 'file' && { mimeType: s.mimeType }),
+      }))
       return {
-        content: [
-          { type: 'text', text: `Objects found: ${summaries.map((s) => s.name).join(', ')}` },
-        ],
+        content: [{ type: 'text', text: JSON.stringify({ results }, null, 2) }],
       }
     },
   }

--- a/packages/auto-mcp-servers/src/auto-drive/index.ts
+++ b/packages/auto-mcp-servers/src/auto-drive/index.ts
@@ -1,16 +1,18 @@
-import { createAutoDriveApi, UploadFileOptions } from '@autonomys/auto-drive'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import * as mcp_types from '@modelcontextprotocol/sdk/types.js'
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
+import { createAutoDriveHandlers } from './handlers.js'
 
-const AUTO_DRIVE_API_KEY = process.env.AUTO_DRIVE_API_KEY
+const AUTO_DRIVE_API_KEY =
+  process.env.AUTO_DRIVE_API_KEY ??
+  (() => {
+    throw new Error('AUTO_DRIVE_API_KEY environment variable is not set')
+  })()
 const NETWORK = process.env.NETWORK === 'taurus' ? 'taurus' : 'mainnet'
 const ENCRYPTION_PASSWORD = process.env.ENCRYPTION_PASSWORD
-const uploadOptions: UploadFileOptions | undefined = ENCRYPTION_PASSWORD
-  ? { password: ENCRYPTION_PASSWORD }
-  : undefined
 
-const autoDriveApi = createAutoDriveApi({ network: NETWORK, apiKey: AUTO_DRIVE_API_KEY })
+const { uploadObjectHandler, downloadObjectHandler, searchObjectsHandler } =
+  createAutoDriveHandlers(AUTO_DRIVE_API_KEY, NETWORK, ENCRYPTION_PASSWORD)
 
 export const autoDriveServer = new McpServer({ name: 'Auto Drive', version: '0.1.1' })
 
@@ -27,12 +29,8 @@ autoDriveServer.tool(
       `,
     ),
   } as any,
-  async ({ filename, data }, extra) => {
-    if (!AUTO_DRIVE_API_KEY) {
-      throw new Error('AUTO_DRIVE_API_KEY environment variable is not set')
-    }
-    const cid = await autoDriveApi.uploadObjectAsJSON({ data }, filename, uploadOptions)
-    return { content: [{ type: 'text', text: `Object uploaded successfully with ${cid}` }] }
+  async ({ filename, data }, _extra): Promise<CallToolResult> => {
+    return await uploadObjectHandler({ filename, data })
   },
 )
 
@@ -42,82 +40,8 @@ autoDriveServer.tool(
   {
     cid: z.string().describe('The Content Identifier (CID) of the object to download.'),
   } as any,
-  async (
-    { cid },
-    _extra,
-    // extra: RequestHandlerExtra, // Infer extra type
-  ): Promise<{ content: mcp_types.TextContent[]; isError?: boolean }> => {
-    if (!AUTO_DRIVE_API_KEY) {
-      throw new Error('AUTO_DRIVE_API_KEY environment variable is not set')
-    }
-    try {
-      // Get object summary to determine type and metadata
-      const summaries = await autoDriveApi.searchByNameOrCID(cid)
-      if (!summaries || summaries.length === 0) {
-        throw new Error(`Object not found for CID: ${cid}`)
-      }
-      const summary = summaries[0]
-
-      // Handle folders
-      if (summary.type === 'folder') {
-        return {
-          isError: true,
-          content: [
-            {
-              type: 'text',
-              text: `Error: CID ${cid} points to a folder, which cannot be downloaded directly with this tool.`,
-            },
-          ],
-        }
-      }
-
-      const mimeType = summary.mimeType || 'application/octet-stream'
-      const filename = summary.name || `download-${cid}`
-
-      // Handle only text-based types
-      if (mimeType.startsWith('text/') || mimeType === 'application/json') {
-        const stream = await autoDriveApi.downloadFile(cid, ENCRYPTION_PASSWORD)
-        let fileBuffer = Buffer.alloc(0)
-        for await (const chunk of stream) {
-          fileBuffer = Buffer.concat([fileBuffer, chunk])
-        }
-        try {
-          const text = fileBuffer.toString('utf-8')
-          return {
-            content: [{ type: 'text', text }],
-          }
-        } catch (e) {
-          console.error(`Failed to decode text content for ${filename} (${mimeType})`, e)
-          return {
-            isError: true,
-            content: [
-              {
-                type: 'text',
-                text: `Error: Failed to decode file content for ${filename} as UTF-8 text.`,
-              },
-            ],
-          }
-        }
-      }
-
-      // For all other types, return an error
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text',
-            text: `Error: File type \'${mimeType}\' is not supported for direct download in this client. Only text/* and application/json are supported.`,
-          },
-        ],
-      }
-    } catch (error: any) {
-      console.error(`Failed to download object with CID ${cid}:`, error)
-      const errorMessage = error.message || 'Unknown error occurred during download.'
-      return {
-        isError: true,
-        content: [{ type: 'text', text: `Error downloading object: ${errorMessage}` }],
-      }
-    }
+  async ({ cid }, _extra): Promise<CallToolResult> => {
+    return await downloadObjectHandler({ cid })
   },
 )
 
@@ -127,36 +51,7 @@ autoDriveServer.tool(
   {
     query: z.string().describe('The name or CID fragment to search for.'),
   } as any,
-  async ({ query }, _extra) => {
-    if (!AUTO_DRIVE_API_KEY) {
-      throw new Error('AUTO_DRIVE_API_KEY environment variable is not set')
-    }
-    try {
-      const results = await autoDriveApi.searchByNameOrCID(query)
-
-      if (results.length === 0) {
-        return {
-          content: [{ type: 'text', text: `No objects found matching query: "${query}"` }],
-        }
-      }
-
-      const resultText = results
-        .map(
-          (summary) =>
-            `- Name: ${summary.name || 'N/A'}\n  CID: ${summary.headCid}\n  Type: ${summary.type}\n  Size: ${summary.size} bytes`,
-        )
-        .join('\n\n')
-
-      return {
-        content: [{ type: 'text', text: `Found ${results.length} object(s):\n\n${resultText}` }],
-      }
-    } catch (error: any) {
-      console.error(`Failed to search objects with query "${query}":`, error)
-      const errorMessage = error.message || 'Unknown error occurred during search.'
-      return {
-        isError: true,
-        content: [{ type: 'text', text: `Error searching objects: ${errorMessage}` }],
-      }
-    }
+  async ({ query }, _extra): Promise<CallToolResult> => {
+    return await searchObjectsHandler({ query })
   },
 )

--- a/packages/auto-mcp-servers/src/auto-drive/index.ts
+++ b/packages/auto-mcp-servers/src/auto-drive/index.ts
@@ -1,5 +1,6 @@
 import { createAutoDriveApi, UploadFileOptions } from '@autonomys/auto-drive'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import * as mcp_types from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 
 const AUTO_DRIVE_API_KEY = process.env.AUTO_DRIVE_API_KEY
@@ -11,7 +12,7 @@ const uploadOptions: UploadFileOptions | undefined = ENCRYPTION_PASSWORD
 
 const autoDriveApi = createAutoDriveApi({ network: NETWORK, apiKey: AUTO_DRIVE_API_KEY })
 
-export const autoDriveServer = new McpServer({ name: 'Auto Drive', version: '0.1.0' })
+export const autoDriveServer = new McpServer({ name: 'Auto Drive', version: '0.1.1' })
 
 autoDriveServer.tool(
   'upload-object',
@@ -32,5 +33,90 @@ autoDriveServer.tool(
     }
     const cid = await autoDriveApi.uploadObjectAsJSON({ data }, filename, uploadOptions)
     return { content: [{ type: 'text', text: `Object uploaded successfully with ${cid}` }] }
+  },
+)
+
+autoDriveServer.tool(
+  'download-object',
+  'Download a text-based object (text/*, application/json) from Auto Drive using its Content Identifier (CID).',
+  {
+    cid: z.string().describe('The Content Identifier (CID) of the object to download.'),
+  } as any,
+  async (
+    { cid },
+    _extra,
+    // extra: RequestHandlerExtra, // Infer extra type
+  ): Promise<{ content: mcp_types.TextContent[]; isError?: boolean }> => {
+    if (!AUTO_DRIVE_API_KEY) {
+      throw new Error('AUTO_DRIVE_API_KEY environment variable is not set')
+    }
+    try {
+      // Get object summary to determine type and metadata
+      const summaries = await autoDriveApi.searchByNameOrCID(cid)
+      if (!summaries || summaries.length === 0) {
+        throw new Error(`Object not found for CID: ${cid}`)
+      }
+      const summary = summaries[0]
+
+      // Handle folders
+      if (summary.type === 'folder') {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Error: CID ${cid} points to a folder, which cannot be downloaded directly with this tool.`,
+            },
+          ],
+        }
+      }
+
+      const mimeType = summary.mimeType || 'application/octet-stream'
+      const filename = summary.name || `download-${cid}`
+
+      // Handle only text-based types
+      if (mimeType.startsWith('text/') || mimeType === 'application/json') {
+        const stream = await autoDriveApi.downloadFile(cid, ENCRYPTION_PASSWORD)
+        let fileBuffer = Buffer.alloc(0)
+        for await (const chunk of stream) {
+          fileBuffer = Buffer.concat([fileBuffer, chunk])
+        }
+        try {
+          const text = fileBuffer.toString('utf-8')
+          return {
+            content: [{ type: 'text', text }],
+          }
+        } catch (e) {
+          console.error(`Failed to decode text content for ${filename} (${mimeType})`, e)
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Error: Failed to decode file content for ${filename} as UTF-8 text.`,
+              },
+            ],
+          }
+        }
+      }
+
+      // For all other types, return an error
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: `Error: File type \'${mimeType}\' is not supported for direct download in this client. Only text/* and application/json are supported.`,
+          },
+        ],
+      }
+    } catch (error: any) {
+      console.error(`Failed to download object with CID ${cid}:`, error)
+      const errorMessage = error.message || 'Unknown error occurred during download.'
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Error downloading object: ${errorMessage}` }],
+      }
+    }
   },
 )

--- a/packages/auto-mcp-servers/src/auto-drive/index.ts
+++ b/packages/auto-mcp-servers/src/auto-drive/index.ts
@@ -14,7 +14,7 @@ const ENCRYPTION_PASSWORD = process.env.ENCRYPTION_PASSWORD
 const { uploadObjectHandler, downloadObjectHandler, searchObjectsHandler } =
   createAutoDriveHandlers(AUTO_DRIVE_API_KEY, NETWORK, ENCRYPTION_PASSWORD)
 
-export const autoDriveServer = new McpServer({ name: 'Auto Drive', version: '0.1.1' })
+export const autoDriveServer = new McpServer({ name: 'Auto Drive', version: '0.1.2' })
 
 autoDriveServer.tool(
   'upload-object',

--- a/packages/auto-mcp-servers/src/auto-drive/index.ts
+++ b/packages/auto-mcp-servers/src/auto-drive/index.ts
@@ -11,11 +11,6 @@ const uploadOptions: UploadFileOptions | undefined = ENCRYPTION_PASSWORD
 
 const autoDriveApi = createAutoDriveApi({ network: NETWORK, apiKey: AUTO_DRIVE_API_KEY })
 
-const uploadObject = async (filename: string, data: unknown) => {
-  const cid = await autoDriveApi.uploadObjectAsJSON({ data }, filename, uploadOptions)
-  return cid
-}
-
 export const autoDriveServer = new McpServer({ name: 'Auto Drive', version: '0.1.0' })
 
 autoDriveServer.tool(
@@ -35,7 +30,7 @@ autoDriveServer.tool(
     if (!AUTO_DRIVE_API_KEY) {
       throw new Error('AUTO_DRIVE_API_KEY environment variable is not set')
     }
-    const cid = await uploadObject(filename, data)
+    const cid = await autoDriveApi.uploadObjectAsJSON({ data }, filename, uploadOptions)
     return { content: [{ type: 'text', text: `Object uploaded successfully with ${cid}` }] }
   },
 )


### PR DESCRIPTION
This pull request introduces significant updates to the `auto-mcp-servers` package, including the addition of new handlers for Auto Drive functionality, improved modularization, and minor version updates. The changes enhance the package's capability to interact with the Autonomys Network for uploading, downloading, and searching objects, while also improving maintainability.

### Auto Drive functionality enhancements:
* Added `createAutoDriveHandlers` in `handlers.ts`, which provides modularized handlers for uploading, downloading, and searching objects on the Autonomys Network. This includes robust error handling and support for text-based file downloads. (`packages/auto-mcp-servers/src/auto-drive/handlers.ts`)
* Updated `autoDriveServer` to include new tools for downloading and searching objects (`download-object` and `search-objects`) in addition to the existing upload functionality. (`packages/auto-mcp-servers/src/auto-drive/index.ts`)

### Codebase modularization:
* Refactored `auto-drive/index.ts` to delegate Auto Drive operations to the new `createAutoDriveHandlers` utility, improving separation of concerns and reducing code duplication. (`packages/auto-mcp-servers/src/auto-drive/index.ts`)

### Package updates:
* Updated the package version from `0.1.1-alpha.2` to `0.1.1` in `package.json`, indicating a stable release. (`packages/auto-mcp-servers/package.json`)
* Simplified the `prepublishOnly` script by removing the `chmod` command, as it is no longer necessary. (`packages/auto-mcp-servers/package.json`)