### PR TITLE
Convert auto-agents to nodenext

### DIFF
--- a/packages/auto-agents/jest.config.js
+++ b/packages/auto-agents/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {

--- a/packages/auto-agents/package.json
+++ b/packages/auto-agents/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.18",
   "license": "MIT",
   "main": "dist/index.js",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/autonomys/auto-sdk"

--- a/packages/auto-agents/src/experiences/cidManager.ts
+++ b/packages/auto-agents/src/experiences/cidManager.ts
@@ -7,9 +7,9 @@ import {
 import { ethers } from 'ethers'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
-import { MEMORY_ABI } from './abi/memory'
-import type { AgentOptions, CidManager, EvmOptions, StoredHash } from './types'
-import { retryWithBackoff } from './utils'
+import { MEMORY_ABI } from './abi/memory.js'
+import type { AgentOptions, CidManager, EvmOptions, StoredHash } from './types.js'
+import { retryWithBackoff } from './utils.js'
 
 /**
  * Converts a bytes32 hex string (presumed Blake3 hash) from the contract to a CID string.

--- a/packages/auto-agents/src/experiences/experienceManager.ts
+++ b/packages/auto-agents/src/experiences/experienceManager.ts
@@ -1,9 +1,9 @@
 import { createAutoDriveApi } from '@autonomys/auto-drive'
 import { ethers } from 'ethers'
-import { createCidManager } from './cidManager'
-import { downloadExperience, uploadExperience } from './experienceStorage'
-import { ExperienceManager, ExperienceManagerOptions, ExperienceSaveResult } from './types'
-import { retryWithBackoff } from './utils'
+import { createCidManager } from './cidManager.js'
+import { downloadExperience, uploadExperience } from './experienceStorage.js'
+import { ExperienceManager, ExperienceManagerOptions, ExperienceSaveResult } from './types.js'
+import { retryWithBackoff } from './utils.js'
 
 /**
  * Creates an ExperienceManager instance for saving and retrieving agent experiences.
@@ -70,7 +70,7 @@ export const createExperienceManager = async ({
         return experience
       },
       {
-        shouldRetry: (error) => {
+        shouldRetry: (error: unknown) => {
           const errorMessage = error instanceof Error ? error.message : String(error)
           return !(
             errorMessage.includes('Not Found') || errorMessage.includes('incorrect header check')

--- a/packages/auto-agents/src/experiences/experienceStorage.ts
+++ b/packages/auto-agents/src/experiences/experienceStorage.ts
@@ -1,6 +1,6 @@
 import { AutoDriveApi } from '@autonomys/auto-drive'
 import { ethers } from 'ethers'
-import { AgentExperience, ExperienceHeader, ExperienceUploadOptions } from './types'
+import { AgentExperience, ExperienceHeader, ExperienceUploadOptions } from './types.js'
 
 export const uploadExperience = async (
   autoDriveApi: AutoDriveApi,

--- a/packages/auto-agents/src/experiences/index.ts
+++ b/packages/auto-agents/src/experiences/index.ts
@@ -1,5 +1,5 @@
 // Re-export the main factory function
-export { createExperienceManager } from './experienceManager'
+export { createExperienceManager } from './experienceManager.js'
 
 // Re-export relevant types for consumers of this package
 export type {

--- a/packages/auto-agents/src/experiences/storage.ts
+++ b/packages/auto-agents/src/experiences/storage.ts
@@ -1,6 +1,6 @@
 import { AutoDriveApi } from '@autonomys/auto-drive'
 import { ethers } from 'ethers'
-import { AgentExperience, ExperienceHeader, ExperienceUploadOptions } from './types'
+import { AgentExperience, ExperienceHeader, ExperienceUploadOptions } from './types.js'
 
 export const uploadExperience = async (
   autoDriveApi: AutoDriveApi,

--- a/packages/auto-agents/src/index.ts
+++ b/packages/auto-agents/src/index.ts
@@ -1,1 +1,1 @@
-export * from './experiences'
+export * from './experiences/index.js'

--- a/packages/auto-agents/tsconfig.json
+++ b/packages/auto-agents/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": "./src"
   },


### PR DESCRIPTION
This pull request updates the `packages/auto-agents` package to fully adopt ES module syntax. The changes include setting the package type to "module," updating import paths to include `.js` extensions, and adjusting TypeScript configurations for proper module resolution.

This was discovered to be required when trying to update `autonomys-agents` to use `auto-agents`, due to `auto-dag-data` dependency.

### ES Module Adoption:

* [`packages/auto-agents/package.json`](diffhunk://#diff-70218131c9706430866405f0b5efa8b22ddcab14e39ad9c6144d40b49402205eR6): Added `"type": "module"` to specify the package as an ES module.
* Updated import statements across multiple files to include `.js` extensions for compatibility with ES module syntax:
  - `packages/auto-agents/src/experiences/cidManager.ts`
  - `packages/auto-agents/src/experiences/experienceManager.ts`
  - `packages/auto-agents/src/experiences/experienceStorage.ts`
  - `packages/auto-agents/src/experiences/index.ts`
  - `packages/auto-agents/src/index.ts`

### TypeScript Configuration:

* [`packages/auto-agents/tsconfig.json`](diffhunk://#diff-d5ba33b0709eafeecf1b09dd1cc99445372db3f9ca84e42e60de146971497513R4-R5): Updated `module` and `moduleResolution` to `NodeNext` for proper handling of ES module syntax in TypeScript.

### Minor Improvements:

* [`packages/auto-agents/src/experiences/experienceManager.ts`](diffhunk://#diff-b0220596363ca33590dfe9ae10a697adb64790b629b7d6639ae7dade0ba0a053L73-R73): Added a type annotation (`: unknown`) to the `error` parameter in the `shouldRetry` function for improved type safety.