### PR TITLE
feat: make server respond to http post request

### DIFF
--- a/packages/utility/rpc/__test__/rpc/typed.spec.ts
+++ b/packages/utility/rpc/__test__/rpc/typed.spec.ts
@@ -47,7 +47,10 @@ describe('rpc/definition', () => {
         test: (params, { connection: _connection }) => {
           // Workaround to get the connection object
           // for the notification test
-          connection = _connection
+          if (_connection) {
+            connection = _connection
+          }
+
           return {
             name: params.name,
           }
@@ -181,5 +184,14 @@ describe('rpc/definition', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 100))
     expect(mock.mock.calls[0][0]).toEqual('test')
+  })
+
+  it('should handle a fetch http request', async () => {
+    const response = await fetch(`http://localhost:${TEST_PORT}`, {
+      method: 'POST',
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'test', params: { name: 'test' }, id: 1 }),
+    })
+    const body = await response.json()
+    expect(body).toEqual({ jsonrpc: '2.0', id: 1, result: { name: 'test' } })
   })
 })

--- a/packages/utility/rpc/__test__/rpc/typed.spec.ts
+++ b/packages/utility/rpc/__test__/rpc/typed.spec.ts
@@ -11,7 +11,7 @@ describe('rpc/definition', () => {
   let httpServer: http.Server
   let connection: connection
 
-  const { createClient, createServer } = createApiDefinition({
+  const { createClient, createServer, createHttpClient } = createApiDefinition({
     methods: {
       test: {
         params: z.object({ name: z.string() }),
@@ -187,11 +187,8 @@ describe('rpc/definition', () => {
   })
 
   it('should handle a fetch http request', async () => {
-    const response = await fetch(`http://localhost:${TEST_PORT}`, {
-      method: 'POST',
-      body: JSON.stringify({ jsonrpc: '2.0', method: 'test', params: { name: 'test' }, id: 1 }),
-    })
-    const body = await response.json()
-    expect(body).toEqual({ jsonrpc: '2.0', id: 1, result: { name: 'test' } })
+    const client = createHttpClient(`http://localhost:${TEST_PORT}`)
+    const result = await client.test({ name: 'test' })
+    expect(result).toEqual({ name: 'test' })
   })
 })

--- a/packages/utility/rpc/__test__/ws/server.spec.ts
+++ b/packages/utility/rpc/__test__/ws/server.spec.ts
@@ -1,6 +1,6 @@
 import http from 'http'
 import { createWsClient, WsClient } from '../../src'
-import { encodeMessage } from '../../src/utils/websocket'
+import { encodeMessageData } from '../../src/utils/websocket'
 import { createWsServer } from '../../src/ws/server'
 import { createBaseHttpServer, TEST_PORT } from '../utils'
 
@@ -57,7 +57,7 @@ describe('Server', () => {
         callbacks: {
           onEveryOpen: async () => {
             resolve(client)
-            client.send(encodeMessage('test'))
+            client.send(encodeMessageData('test'))
           },
         },
       })

--- a/packages/utility/rpc/src/rpc/api/definition.ts
+++ b/packages/utility/rpc/src/rpc/api/definition.ts
@@ -1,4 +1,5 @@
 import Websocket from 'websocket'
+import { randomId } from '../../utils'
 import { createRpcClient } from '../client'
 import { createRpcServer } from '../server'
 import { Message, MessageQuery, RpcParams, TypedRpcNotificationHandler } from '../types'
@@ -144,7 +145,7 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
               jsonrpc: '2.0',
               method,
               params,
-              id: Math.floor(Math.random() * 65535),
+              id: randomId(),
             }),
           })
 

--- a/packages/utility/rpc/src/rpc/client.ts
+++ b/packages/utility/rpc/src/rpc/client.ts
@@ -1,4 +1,5 @@
 import Websocket from 'websocket'
+import { randomId } from '../utils'
 import { parseData } from '../utils/websocket'
 import { createWsClient } from '../ws/client'
 import { WsClient } from '../ws/types'
@@ -49,7 +50,7 @@ export const createRpcClient = ({
   let onMessageCallbacks: ClientRPCListener[] = []
 
   const send = async (message: MessageQuery) => {
-    const id = message.id ?? Math.floor(Math.random() * 65546)
+    const id = message.id ?? randomId()
     const messageWithID = { ...message, id }
 
     return new Promise<MessageResponse>((resolve, reject) => {

--- a/packages/utility/rpc/src/rpc/server.ts
+++ b/packages/utility/rpc/src/rpc/server.ts
@@ -1,4 +1,7 @@
+import http from 'http'
+import { connection } from 'websocket'
 import { safeExecute } from '../utils/error'
+import { parseHttpBody } from '../utils/http'
 import { safeParseJson } from '../utils/json'
 import { parseMessage } from '../utils/websocket'
 import { WsServer } from '../ws'
@@ -28,6 +31,70 @@ export const createRpcServer = ({
   const wsServer = isWsServer(server) ? server : createWsServer(server)
   const handlers = initialHandlers ?? []
 
+  const handleMessage = async ({
+    object,
+    send,
+    connection,
+  }: {
+    object: object
+    send: (msg: string) => void
+    connection?: connection
+  }) => {
+    // Parse the message to ensure it matches the base schema
+    const parsedMessage = messageSchema.safeParse(object)
+    if (!parsedMessage.success) {
+      send(JSON.stringify({ error: 'JSON message does not match RPC base schema' }))
+      return
+    }
+
+    const sendMessageWithId = (message: MessageResponseQuery) => {
+      send(JSON.stringify(wrapResponse(message, parsedMessage.data.id)))
+    }
+
+    // Find the handler for the message
+    const handler = handlers.find(
+      (handler) => parsedMessage.data.method === handler.method,
+    )?.handler
+    if (!handler) {
+      send(
+        JSON.stringify(
+          wrapResponse(
+            {
+              error: { code: 404, message: 'Method not found' },
+              jsonrpc: '2.0',
+            },
+            parsedMessage.data.id,
+          ),
+        ),
+      )
+      return
+    }
+
+    const catchError = (error: Error): MessageResponseQuery => {
+      if (error instanceof RpcError) {
+        return errorResponse(error.code, error.message)
+      } else {
+        return errorResponse(RpcError.Code.InternalError, error?.message ?? 'Unknown error')
+      }
+    }
+
+    // Handle the message and send the response if it exists
+    const response = await safeExecute(
+      async () =>
+        await handler(parsedMessage.data.params, {
+          send,
+          connection,
+          messageId: parsedMessage.data.id,
+        }),
+    ).catch(catchError)
+
+    if (parsedMessage.data.id && response) {
+      sendMessageWithId(response)
+    } else if (response) {
+      send(JSON.stringify(wrapResponse(response, undefined)))
+    }
+  }
+
   wsServer.onMessage(async (msg, { connection }) => {
     try {
       const utf8Data = parseMessage(msg)
@@ -37,63 +104,36 @@ export const createRpcServer = ({
         return
       }
 
-      // Parse the message to ensure it matches the base schema
-      const parsedMessage = messageSchema.safeParse(object)
-      if (!parsedMessage.success) {
-        connection.sendUTF(JSON.stringify({ error: 'JSON message does not match RPC base schema' }))
-        return
-      }
-
-      const sendMessageWithId = (message: MessageResponseQuery) => {
-        connection.sendUTF(JSON.stringify(wrapResponse(message, parsedMessage.data.id)))
-      }
-
-      // Find the handler for the message
-      const handler = handlers.find(
-        (handler) => parsedMessage.data.method === handler.method,
-      )?.handler
-      if (!handler) {
-        connection.sendUTF(
-          JSON.stringify(
-            wrapResponse(
-              {
-                error: { code: 404, message: 'Method not found' },
-                jsonrpc: '2.0',
-              },
-              parsedMessage.data.id,
-            ),
-          ),
-        )
-        return
-      }
-
-      const catchError = (error: Error): MessageResponseQuery => {
-        if (error instanceof RpcError) {
-          return errorResponse(error.code, error.message)
-        } else {
-          return errorResponse(RpcError.Code.InternalError, error?.message ?? 'Unknown error')
-        }
-      }
-
-      // Handle the message and send the response if it exists
-      const response = await safeExecute(
-        async () =>
-          await handler(parsedMessage.data.params, {
-            connection,
-            messageId: parsedMessage.data.id,
-          }),
-      ).catch(catchError)
-
-      if (parsedMessage.data.id && response) {
-        sendMessageWithId(response)
-      } else if (response) {
-        connection.sendUTF(JSON.stringify(wrapResponse(response, undefined)))
-      }
+      handleMessage({ object, send: (msg) => connection.sendUTF(msg), connection })
     } catch {
       connection.sendUTF(JSON.stringify({ error: 'Unknown error' }))
       return
     }
   })
+
+  const onHttpRequest = async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    try {
+      const body = await parseHttpBody(req)
+      if (!body) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Invalid JSON message' }))
+        return
+      }
+
+      const object = safeParseJson(body)
+      if (!object) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Invalid JSON message' }))
+        return
+      }
+
+      handleMessage({ object, send: (msg) => res.end(msg) })
+    } catch {
+      res.writeHead(500, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Unknown error' }))
+    }
+  }
+  wsServer.onHttpRequest(onHttpRequest)
 
   const addRpcHandler = <I, O extends RpcResponse>(handler: RpcHandler<I, O>) => {
     handlers.push(handler)

--- a/packages/utility/rpc/src/rpc/types.ts
+++ b/packages/utility/rpc/src/rpc/types.ts
@@ -60,7 +60,8 @@ export type RpcClientResponder = (message: MessageResponseQuery) => void
 export type ClientRPCListener = ((message: Message) => void) | ((message: MessageResponse) => void)
 
 export type RpcParams = {
-  connection: connection
+  send: (msg: string) => void
+  connection?: connection
   messageId?: number
 }
 
@@ -75,7 +76,8 @@ export type RpcHandler<I, O extends RpcResponse> = {
 }
 
 export type TypedRpcParams<S extends ApiDefinition> = {
-  connection: connection
+  send: (msg: string) => void
+  connection?: connection
   messageId?: number
   notificationClient: ApiServerNotifications<S>
 }

--- a/packages/utility/rpc/src/utils/http.ts
+++ b/packages/utility/rpc/src/utils/http.ts
@@ -1,0 +1,18 @@
+import http from 'http'
+
+export const parseHttpBody = (req: http.IncomingMessage): Promise<string | null> => {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk) => {
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8')
+      resolve(body)
+    })
+    req.on('error', (error) => {
+      console.error('Error parsing HTTP body', error)
+      resolve(null)
+    })
+  })
+}

--- a/packages/utility/rpc/src/utils/misc.ts
+++ b/packages/utility/rpc/src/utils/misc.ts
@@ -1,3 +1,5 @@
 export const unresolvablePromise = new Promise<void>(() => {})
 
 export const schedule = setTimeout
+
+export const randomId = () => Math.floor(Math.random() * 65535)

--- a/packages/utility/rpc/src/utils/websocket.ts
+++ b/packages/utility/rpc/src/utils/websocket.ts
@@ -15,10 +15,17 @@ export const parseMessage = (message: Websocket.Message): string => {
   }
 }
 
-export const encodeMessage = (message: Websocket.IMessageEvent['data']): Buffer => {
+export const encodeMessageData = (message: Websocket.IMessageEvent['data']): Buffer => {
   if (typeof message === 'string') {
     return Buffer.from(message)
   } else {
     return Buffer.from(message)
+  }
+}
+
+export const encodeMessage = (message: Websocket.IMessageEvent['data']): Websocket.Message => {
+  return {
+    type: 'utf8',
+    utf8Data: encodeMessageData(message).toString('utf8'),
   }
 }

--- a/packages/utility/rpc/src/ws/server.ts
+++ b/packages/utility/rpc/src/ws/server.ts
@@ -69,10 +69,15 @@ export const createWsServer = ({
     internalHttpServer.listen(port, cb)
   }
 
+  const onHttpRequest = (fn: (req: http.IncomingMessage, res: http.ServerResponse) => void) => {
+    httpServer.on('request', fn)
+  }
+
   return {
     broadcastMessage,
     onMessage,
     close,
     listen,
+    onHttpRequest,
   }
 }

--- a/packages/utility/rpc/src/ws/types.ts
+++ b/packages/utility/rpc/src/ws/types.ts
@@ -1,3 +1,4 @@
+import http from 'http'
 import Websocket from 'websocket'
 
 export interface WsServer {
@@ -5,6 +6,7 @@ export interface WsServer {
   onMessage: (cb: WsMessageCallback) => void
   close: () => void
   listen: (port: number, cb?: () => void) => void
+  onHttpRequest: (fn: (req: http.IncomingMessage, res: http.ServerResponse) => void) => void
 }
 
 export type WsMessageCallback = (

--- a/packages/utility/rpc/tsconfig.json
+++ b/packages/utility/rpc/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "./src",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "isolatedModules": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
The server was only responding to messages when connected only through `ws`. This means if a http request was performed the server won't respond this PR updates this behaviour