### PR TITLE
Add Agent Experiences MCP Server and Improve CID Manager functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ install-state.gz
 
 # Forge std
 lib/
+
+.cursor/rules/

--- a/packages/auto-agents/src/experiences/types.ts
+++ b/packages/auto-agents/src/experiences/types.ts
@@ -81,10 +81,13 @@ export type ExperienceUploadOptions = {
 export type EvmOptions = {
   /** The private key of the wallet used for signing or transactions. */
   privateKey: string
-  /** The URL of the EVM-compatible JSON-RPC endpoint. */
-  rpcUrl: string
-  /** The address of the smart contract to interact with (e.g., for storing CIDs). */
-  contractAddress: string
+  /** Information about the smart contract to interact with (e.g., for storing CIDs). */
+  contractInfo?: {
+    /** The URL of the EVM-compatible JSON-RPC endpoint. */
+    rpcUrl: string
+    /** The address of the smart contract to interact with (e.g., for storing CIDs). */
+    contractAddress: string
+  }
 }
 
 /**

--- a/packages/auto-agents/src/experiences/types.ts
+++ b/packages/auto-agents/src/experiences/types.ts
@@ -28,7 +28,6 @@ export type AgentExperience = {
 
 /**
  * Represents the structure of an older version (V0) of the agent experience.
- * @deprecated Use AgentExperience for new implementations.
  */
 export type AgentExperienceV0 = {
   /** Timestamp of the experience generation. */

--- a/packages/auto-mcp-servers/README.md
+++ b/packages/auto-mcp-servers/README.md
@@ -16,6 +16,17 @@ The Auto Drive server provides the following tools:
 - `download-object`: Download a text-based object (`text/*` or `application/json`) from the Autonomys network using its CID.
 - `search-objects`: Search for objects on the Autonomys network by name or CID fragment. Returns a JSON object containing an array of results, each including the object's name, CID, type, size, and mimeType (for files).
 
+### Auto Experiences Server
+
+The Auto Experiences server exposes functionality from the `@autonomys/auto-agents` package as MCP tools, specifically for managing agent experiences.
+
+#### Tools
+
+The Auto Experiences server provides the following tools:
+
+- `save-experience`: Saves agent experience data to the Autonomys network, uploads the data to AutoDrive, and updates the last experience CID. Returns the new CID, previous CID (if any), and EVM transaction hash (if available).
+- `retrieve-experience`: Retrieves an agent experience from the Autonomys network using its CID. Returns the full experience object including headers and data.
+
 More servers and tools will be coming soon!
 
 ## Usage
@@ -36,6 +47,21 @@ More servers and tools will be coming soon!
         "ENCRYPTION_PASSWORD": "my-password (optional)",
         "NETWORK": "mainnet or taurus (optional, defaults to mainnet)"
       }
+    },
+    "auto-experiences": {
+      "command": "npx",
+      "args": ["-y", "@autonomys/auto-mcp-servers", "auto-experiences"],
+      "env": {
+        "AUTO_DRIVE_API_KEY": "your-api-key",
+        "AGENT_PATH": "your-agent-path",
+        "AGENT_NAME": "your-agent-name",
+        "PRIVATE_KEY": "your-wallet-private-key",
+        "NETWORK": "mainnet or taurus (optional, defaults to mainnet)",
+        "UPLOAD_ENCRYPTION_PASSWORD": "my-password (optional)",
+        "AGENT_VERSION": "your-agent-version (optional)",
+        "RPC_URL": "your-evm-rpc-url (optional)",
+        "CONTRACT_ADDRESS": "your-contract-address (optional)"
+      }
     }
   }
 }
@@ -47,7 +73,7 @@ More servers and tools will be coming soon!
 
 You can use these MCP servers as tools with agent frameworks such as LangChain.
 
-1. Install the Auto Drive server into your project:
+1. Install the Auto MCP servers into your project:
 
 ```bash
 npm install @autonomys/auto-mcp-servers
@@ -94,6 +120,34 @@ const result = await model
   .bindTools(tools)
   .invoke('Upload a profound thought to the Autonomys network')
 console.log(result)
+```
+
+3. Use the Auto Experiences server in a similar way:
+
+```typescript
+// Create Auto Experiences tools
+const createAutoExperiencesTools = async (config: {
+  apiKey: string
+  agentPath: string
+  agentName: string
+  privateKey: string
+}): Promise<StructuredToolInterface[]> => {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ['node_modules/.bin/auto-experiences-server'],
+    env: {
+      AUTO_DRIVE_API_KEY: config.apiKey,
+      AGENT_PATH: config.agentPath,
+      AGENT_NAME: config.agentName,
+      PRIVATE_KEY: config.privateKey,
+    },
+  })
+
+  const client = new Client({ name: 'auto-experiences', version: '0.0.1' })
+  client.connect(transport)
+
+  return await loadMcpTools('auto-experiences', client)
+}
 ```
 
 ## License

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -19,6 +19,7 @@
   "main": "dist/index.js",
   "bin": {
     "auto-drive-server": "./dist/bin/auto-drive.js",
+    "auto-experiences-server": "./dist/bin/auto-experiences.js",
     "auto-mcp-servers": "./dist/bin/main.js"
   },
   "scripts": {
@@ -30,6 +31,7 @@
     "server"
   ],
   "dependencies": {
+    "@autonomys/auto-agents": "^0.1.0",
     "@autonomys/auto-drive": "^1.4.18",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "zod": "^3.24.2"

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -31,7 +31,7 @@
     "server"
   ],
   "dependencies": {
-    "@autonomys/auto-agents": "^0.1.0",
+    "@autonomys/auto-agents": "^1.4.18",
     "@autonomys/auto-drive": "^1.4.18",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "zod": "^3.24.2"

--- a/packages/auto-mcp-servers/src/auto-drive/handlers.ts
+++ b/packages/auto-mcp-servers/src/auto-drive/handlers.ts
@@ -18,7 +18,7 @@ export const createAutoDriveHandlers = (
       data,
     }: {
       filename: string
-      data: Record<string, any>
+      data: Record<string, unknown>
     }): Promise<CallToolResult> => {
       const cid = await autoDriveApi.uploadObjectAsJSON({ data }, filename, uploadOptions)
       return { content: [{ type: 'text', text: `Object uploaded successfully with ${cid}` }] }
@@ -80,10 +80,11 @@ export const createAutoDriveHandlers = (
           content: [
             {
               type: 'text',
-              text: `Error: File type \'${mimeType}\' is not supported for direct download in this client. Only text/* and application/json are supported.`,
+              text: `Error: File type '${mimeType}' is not supported for direct download in this client. Only text/* and application/json are supported.`,
             },
           ],
         }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
         console.error(`Failed to download object with CID ${cid}:`, error)
         const errorMessage = error.message || 'Unknown error occurred during download.'

--- a/packages/auto-mcp-servers/src/auto-drive/index.ts
+++ b/packages/auto-mcp-servers/src/auto-drive/index.ts
@@ -28,8 +28,8 @@ autoDriveServer.tool(
       The values are the actual data being stored.
       `,
     ),
-  } as any,
-  async ({ filename, data }, _extra): Promise<CallToolResult> => {
+  },
+  async ({ filename, data }): Promise<CallToolResult> => {
     return await uploadObjectHandler({ filename, data })
   },
 )
@@ -39,8 +39,8 @@ autoDriveServer.tool(
   'Download a text-based object (text/*, application/json) from the Autonomys Network using Auto Drive using its Content Identifier (CID).',
   {
     cid: z.string().describe('The Content Identifier (CID) of the object to download.'),
-  } as any,
-  async ({ cid }, _extra): Promise<CallToolResult> => {
+  },
+  async ({ cid }): Promise<CallToolResult> => {
     return await downloadObjectHandler({ cid })
   },
 )
@@ -50,8 +50,8 @@ autoDriveServer.tool(
   'Search for objects on the Autonomys Network using Auto Drive by name or CID.',
   {
     query: z.string().describe('The name or CID fragment to search for.'),
-  } as any,
-  async ({ query }, _extra): Promise<CallToolResult> => {
+  },
+  async ({ query }): Promise<CallToolResult> => {
     return await searchObjectsHandler({ query })
   },
 )

--- a/packages/auto-mcp-servers/src/auto-experiences/handlers.ts
+++ b/packages/auto-mcp-servers/src/auto-experiences/handlers.ts
@@ -8,10 +8,50 @@ import {
   ExperienceSaveResult,
 } from '@autonomys/auto-agents/dist/experiences/types.js'
 
-export const createExperienceHandlers = async (options: ExperienceManagerOptions) => {
-  // Initialize ExperienceManager - this handles CidManager and AutoDrive interactions internally
-  const experienceManager = await createExperienceManager(options)
+// Define a type for the ExperienceManager to help with typing
+type ExperienceManager = Awaited<ReturnType<typeof createExperienceManager>>
 
+// Store a singleton instance to ensure we only create one ExperienceManager
+let experienceManagerInstance: ExperienceManager | undefined
+let experienceManagerPromise: Promise<ExperienceManager> | undefined
+
+/**
+ * Ensures that the ExperienceManager is only created once and properly initialized.
+ * @param options Configuration options for the ExperienceManager
+ * @returns A promise that resolves to the ExperienceManager instance
+ */
+const getExperienceManager = async (
+  options: ExperienceManagerOptions,
+): Promise<ExperienceManager> => {
+  // Return existing instance if already created
+  if (experienceManagerInstance) {
+    return experienceManagerInstance
+  }
+
+  // Return in-flight promise if initialization is already in progress
+  if (experienceManagerPromise) {
+    return experienceManagerPromise
+  }
+
+  // Create a new initialization promise
+  console.error('Creating ExperienceManager instance...')
+  experienceManagerPromise = createExperienceManager(options)
+    .then((manager) => {
+      console.error('ExperienceManager created successfully')
+      experienceManagerInstance = manager
+      return manager
+    })
+    .catch((error) => {
+      console.error('Failed to create ExperienceManager:', error)
+      // Clear promise so next call will try again
+      experienceManagerPromise = undefined
+      throw error
+    })
+
+  return experienceManagerPromise
+}
+
+export const createExperienceHandlers = (options: ExperienceManagerOptions) => {
   return {
     /**
      * Saves the provided agent experience data.
@@ -21,12 +61,15 @@ export const createExperienceHandlers = async (options: ExperienceManagerOptions
     saveExperienceHandler: async ({
       data,
     }: {
-      data: Record<string, unknown> | unknown[] // Allow object or array data
+      data: Record<string, unknown> | unknown[] | string // Allow object or array data
     }): Promise<CallToolResult> => {
       try {
+        const experienceManager = await getExperienceManager(options)
         // saveExperience handles header creation, upload, and saving the latest CID
         const result: ExperienceSaveResult = await experienceManager.saveExperience(data)
-        const responseText = `Experience saved successfully. CID: ${result.cid}${result.previousCid ? `, Previous CID: ${result.previousCid}` : ''}${result.evmHash ? `, EVM Tx: ${result.evmHash}` : ', EVM save skipped/failed.'}`
+        const responseText = `Experience saved successfully. CID: ${result.cid}${
+          result.previousCid ? `, Previous CID: ${result.previousCid}` : ''
+        }${result.evmHash ? `, EVM Tx: ${result.evmHash}` : ', EVM save skipped/failed.'}`
         return { content: [{ type: 'text', text: responseText }] }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
@@ -44,6 +87,7 @@ export const createExperienceHandlers = async (options: ExperienceManagerOptions
      */
     retrieveExperienceHandler: async ({ cid }: { cid: string }): Promise<CallToolResult> => {
       try {
+        const experienceManager = await getExperienceManager(options)
         // retrieveExperience handles download and potential retries
         const experience: AgentExperience | AgentExperienceV0 =
           await experienceManager.retrieveExperience(cid)

--- a/packages/auto-mcp-servers/src/auto-experiences/handlers.ts
+++ b/packages/auto-mcp-servers/src/auto-experiences/handlers.ts
@@ -21,13 +21,14 @@ export const createExperienceHandlers = async (options: ExperienceManagerOptions
     saveExperienceHandler: async ({
       data,
     }: {
-      data: Record<string, any> | any[] // Allow object or array data
+      data: Record<string, unknown> | unknown[] // Allow object or array data
     }): Promise<CallToolResult> => {
       try {
         // saveExperience handles header creation, upload, and saving the latest CID
         const result: ExperienceSaveResult = await experienceManager.saveExperience(data)
         const responseText = `Experience saved successfully. CID: ${result.cid}${result.previousCid ? `, Previous CID: ${result.previousCid}` : ''}${result.evmHash ? `, EVM Tx: ${result.evmHash}` : ', EVM save skipped/failed.'}`
         return { content: [{ type: 'text', text: responseText }] }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
         console.error('Failed to save experience:', error)
         return {
@@ -48,6 +49,7 @@ export const createExperienceHandlers = async (options: ExperienceManagerOptions
           await experienceManager.retrieveExperience(cid)
         // Return the full experience object (header + data or V0 structure) as JSON string
         return { content: [{ type: 'text', text: JSON.stringify(experience, null, 2) }] }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
         console.error(`Failed to retrieve experience for CID ${cid}:`, error)
         // Provide more specific error if possible (e.g., Not Found)

--- a/packages/auto-mcp-servers/src/auto-experiences/handlers.ts
+++ b/packages/auto-mcp-servers/src/auto-experiences/handlers.ts
@@ -1,0 +1,64 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+// Use ExperienceManager for saving/retrieving full experiences
+import { createExperienceManager } from '@autonomys/auto-agents'
+import {
+  AgentExperience,
+  AgentExperienceV0,
+  ExperienceManagerOptions,
+  ExperienceSaveResult,
+} from '@autonomys/auto-agents/dist/experiences/types.js'
+
+export const createExperienceHandlers = async (options: ExperienceManagerOptions) => {
+  // Initialize ExperienceManager - this handles CidManager and AutoDrive interactions internally
+  const experienceManager = await createExperienceManager(options)
+
+  return {
+    /**
+     * Saves the provided agent experience data.
+     * Uploads data to AutoDrive and updates the last experience CID.
+     * @param data - The experience data (JSON object).
+     */
+    saveExperienceHandler: async ({
+      data,
+    }: {
+      data: Record<string, any> | any[] // Allow object or array data
+    }): Promise<CallToolResult> => {
+      try {
+        // saveExperience handles header creation, upload, and saving the latest CID
+        const result: ExperienceSaveResult = await experienceManager.saveExperience(data)
+        const responseText = `Experience saved successfully. CID: ${result.cid}${result.previousCid ? `, Previous CID: ${result.previousCid}` : ''}${result.evmHash ? `, EVM Tx: ${result.evmHash}` : ', EVM save skipped/failed.'}`
+        return { content: [{ type: 'text', text: responseText }] }
+      } catch (error: any) {
+        console.error('Failed to save experience:', error)
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Error saving experience: ${error.message}` }],
+        }
+      }
+    },
+
+    /**
+     * Retrieves an agent experience from AutoDrive using its CID.
+     * @param cid - The CID of the experience to retrieve.
+     */
+    retrieveExperienceHandler: async ({ cid }: { cid: string }): Promise<CallToolResult> => {
+      try {
+        // retrieveExperience handles download and potential retries
+        const experience: AgentExperience | AgentExperienceV0 =
+          await experienceManager.retrieveExperience(cid)
+        // Return the full experience object (header + data or V0 structure) as JSON string
+        return { content: [{ type: 'text', text: JSON.stringify(experience, null, 2) }] }
+      } catch (error: any) {
+        console.error(`Failed to retrieve experience for CID ${cid}:`, error)
+        // Provide more specific error if possible (e.g., Not Found)
+        const errorMessage = error.message?.includes('Not Found')
+          ? `Experience not found for CID: ${cid}`
+          : `Error retrieving experience: ${error.message}`
+        return {
+          isError: true,
+          content: [{ type: 'text', text: errorMessage }],
+        }
+      }
+    },
+  }
+}

--- a/packages/auto-mcp-servers/src/auto-experiences/index.ts
+++ b/packages/auto-mcp-servers/src/auto-experiences/index.ts
@@ -98,7 +98,7 @@ initializeHandlers()
           .describe('The agent experience data to save (JSON object or array).'),
       },
 
-      async (args: { data: Record<string, any> | any[] }, _extra): Promise<CallToolResult> => {
+      async (args: { data: Record<string, unknown> | unknown[] }): Promise<CallToolResult> => {
         if (!experienceHandlers) throw new Error('Handlers not initialized')
         // Access data via args.data
         return await experienceHandlers.saveExperienceHandler({ data: args.data })
@@ -116,7 +116,7 @@ initializeHandlers()
           .describe('The Content Identifier (CID) string of the experience to retrieve.'),
       },
       // cb: (args, extra) => Promise<CallToolResult>
-      async (args: { cid: string }, _extra): Promise<CallToolResult> => {
+      async (args: { cid: string }): Promise<CallToolResult> => {
         if (!experienceHandlers) throw new Error('Handlers not initialized')
         // Access cid via args.cid
         return await experienceHandlers.retrieveExperienceHandler({ cid: args.cid })

--- a/packages/auto-mcp-servers/src/auto-experiences/index.ts
+++ b/packages/auto-mcp-servers/src/auto-experiences/index.ts
@@ -1,0 +1,131 @@
+import { ExperienceManagerOptions } from '@autonomys/auto-agents'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { createExperienceHandlers } from './handlers'
+
+// AutoDrive Config
+const AUTO_DRIVE_API_KEY =
+  process.env.AUTO_DRIVE_API_KEY ??
+  (() => {
+    throw new Error('AUTO_DRIVE_API_KEY env var missing')
+  })()
+const NETWORK = process.env.NETWORK === 'taurus' ? 'taurus' : 'mainnet'
+const UPLOAD_ENCRYPTION_PASSWORD = process.env.UPLOAD_ENCRYPTION_PASSWORD
+
+// Agent Config
+const AGENT_PATH =
+  process.env.AGENT_PATH ??
+  (() => {
+    throw new Error('AGENT_PATH env var missing')
+  })()
+const AGENT_NAME =
+  process.env.AGENT_NAME ??
+  (() => {
+    throw new Error('AGENT_NAME env var missing')
+  })()
+const AGENT_VERSION = process.env.AGENT_VERSION // Optional
+
+// Wallet / EVM Config
+const RPC_URL = process.env.RPC_URL
+const PRIVATE_KEY = process.env.PRIVATE_KEY
+const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS
+
+// Construct ExperienceManagerOptions
+const experienceManagerOptions: ExperienceManagerOptions = {
+  autoDriveApiOptions: {
+    apiKey: AUTO_DRIVE_API_KEY,
+    network: NETWORK,
+  },
+  agentOptions: {
+    agentPath: AGENT_PATH,
+    agentName: AGENT_NAME,
+    ...(AGENT_VERSION && { agentVersion: AGENT_VERSION }),
+  },
+  // Wallet options are required by ExperienceManager for signing uploads, even if EVM isn't used for CID storage
+  walletOptions: {
+    ...(RPC_URL && CONTRACT_ADDRESS
+      ? {
+          contractInfo: {
+            rpcUrl: RPC_URL,
+            contractAddress: CONTRACT_ADDRESS,
+          },
+        }
+      : {}),
+    privateKey:
+      PRIVATE_KEY ??
+      (() => {
+        throw new Error('PRIVATE_KEY env var missing')
+      })(),
+  },
+  // Ensure uploadOptions is always present and includes required fields
+  uploadOptions: {
+    ...(UPLOAD_ENCRYPTION_PASSWORD && { password: UPLOAD_ENCRYPTION_PASSWORD }),
+    compression: true,
+  },
+}
+
+// Check if EVM details are partially missing for CID storage, Wallet is still needed for signing
+if (!RPC_URL || !CONTRACT_ADDRESS) {
+  console.error(
+    'EVM environment variables (RPC_URL, CONTRACT_ADDRESS) not fully set. Experience manager will operate in offline mode with local-only CID storage. Wallet private key IS still required for signing uploads.',
+  )
+}
+
+// --- Initialize Handlers ---
+let experienceHandlers: Awaited<ReturnType<typeof createExperienceHandlers>>
+
+const initializeHandlers = async () => {
+  experienceHandlers = await createExperienceHandlers(experienceManagerOptions)
+}
+
+// --- Create MCP Server ---
+export const autoExperiencesServer = new McpServer({ name: 'Auto Experiences', version: '0.2.0' })
+
+// --- Define and Register Tools ---
+initializeHandlers()
+  .then(() => {
+    console.log('Auto Experiences Handlers Initialized.')
+
+    // Register save-experience tool
+    autoExperiencesServer.tool(
+      'save-experience', // name: string
+      'Saves the provided agent experience data. Uploads to AutoDrive and updates the last experience CID.', // description: string
+      {
+        // paramsSchema: ZodRawShape
+        data: z
+          .union([z.record(z.string(), z.any()), z.array(z.any())])
+          .describe('The agent experience data to save (JSON object or array).'),
+      },
+
+      async (args: { data: Record<string, any> | any[] }, _extra): Promise<CallToolResult> => {
+        if (!experienceHandlers) throw new Error('Handlers not initialized')
+        // Access data via args.data
+        return await experienceHandlers.saveExperienceHandler({ data: args.data })
+      },
+    )
+
+    // Register retrieve-experience tool
+    autoExperiencesServer.tool(
+      'retrieve-experience', // name: string
+      'Retrieves an agent experience from AutoDrive using its CID.', // description: string
+      {
+        // paramsSchema: ZodRawShape
+        cid: z
+          .string()
+          .describe('The Content Identifier (CID) string of the experience to retrieve.'),
+      },
+      // cb: (args, extra) => Promise<CallToolResult>
+      async (args: { cid: string }, _extra): Promise<CallToolResult> => {
+        if (!experienceHandlers) throw new Error('Handlers not initialized')
+        // Access cid via args.cid
+        return await experienceHandlers.retrieveExperienceHandler({ cid: args.cid })
+      },
+    )
+
+    console.log('Auto Experiences MCP tools registered.')
+  })
+  .catch((error) => {
+    console.error('Failed to initialize Auto Experiences handlers:', error)
+    process.exit(1)
+  })

--- a/packages/auto-mcp-servers/src/bin/auto-drive.ts
+++ b/packages/auto-mcp-servers/src/bin/auto-drive.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { autoDriveServer } from '../index.js'
+import { autoDriveServer } from '../auto-drive/index.js'
 
 const main = async () => {
   const transport = new StdioServerTransport()

--- a/packages/auto-mcp-servers/src/bin/auto-experiences.ts
+++ b/packages/auto-mcp-servers/src/bin/auto-experiences.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+// Import directly from the root index file
+import { autoExperiencesServer } from '../index.js'
+
+// Main function with improved error handling and process management
+const main = async () => {
+  try {
+    console.error('Starting Auto Experiences MCP server...')
+
+    // Create transport
+    const transport = new StdioServerTransport()
+
+    // Connect to transport (this initiates message handling)
+    await autoExperiencesServer.connect(transport)
+    console.error('Auto Experiences server running and ready to accept requests')
+  } catch (error) {
+    console.error('Failed to start Auto Experiences server:', error)
+    process.exit(1)
+  }
+}
+
+// Execute main function with global error handling
+main().catch((error) => {
+  console.error('Unhandled error in main():', error)
+  process.exit(1)
+})

--- a/packages/auto-mcp-servers/src/bin/auto-experiences.ts
+++ b/packages/auto-mcp-servers/src/bin/auto-experiences.ts
@@ -2,7 +2,7 @@
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 // Import directly from the root index file
-import { autoExperiencesServer } from '../index.js'
+import { autoExperiencesServer } from '../auto-experiences/index.js'
 
 // Main function with improved error handling and process management
 const main = async () => {

--- a/packages/auto-mcp-servers/src/bin/main.ts
+++ b/packages/auto-mcp-servers/src/bin/main.ts
@@ -2,19 +2,32 @@
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { autoDriveServer } from '../auto-drive/index.js'
+import { autoExperiencesServer } from '../auto-experiences/index.js'
 
 const showHelp = () => {
-  console.log(`
+  console.error(`
 Usage: auto-mcp-servers [server-name]
 
 Available servers:
-  auto-drive    Start the Auto Drive MCP server
+  auto-drive       Start the Auto Drive MCP server
+  auto-experiences Start the Auto Experiences MCP server
 
 Environment variables:
   For Auto Drive server:
     AUTO_DRIVE_API_KEY     API key for Auto Drive (required)
     NETWORK                'mainnet' (default) or 'taurus'
     ENCRYPTION_PASSWORD    Password for encryption (optional)
+
+  For Auto Experiences server:
+    AUTO_DRIVE_API_KEY     API key for Auto Drive (required)
+    NETWORK                'mainnet' (default) or 'taurus'
+    UPLOAD_ENCRYPTION_PASSWORD  Password for encryption (optional)
+    AGENT_PATH             Path to agent (required)
+    AGENT_NAME             Name of agent (required)
+    AGENT_VERSION          Version of agent (optional)
+    PRIVATE_KEY            Wallet private key (required)
+    RPC_URL                EVM RPC URL (optional)
+    CONTRACT_ADDRESS       Contract address (optional)
   `)
   process.exit(1)
 }
@@ -23,23 +36,33 @@ const main = async () => {
   const serverName = process.argv[2] || 'auto-drive'
   const transport = new StdioServerTransport()
 
-  switch (serverName) {
-    case 'auto-drive':
-      await autoDriveServer.connect(transport)
-      break
-    case 'help':
-    case '--help':
-    case '-h':
-      showHelp()
-      break
-    default:
-      console.error(`Unknown server: ${serverName}`)
-      showHelp()
-      break
+  try {
+    switch (serverName) {
+      case 'auto-drive':
+        console.error('Starting Auto Drive MCP server...')
+        await autoDriveServer.connect(transport)
+        break
+      case 'auto-experiences':
+        console.error('Starting Auto Experiences MCP server...')
+        await autoExperiencesServer.connect(transport)
+        break
+      case 'help':
+      case '--help':
+      case '-h':
+        showHelp()
+        break
+      default:
+        console.error(`Unknown server: ${serverName}`)
+        showHelp()
+        break
+    }
+  } catch (error) {
+    console.error(`Failed to start ${serverName} server:`, error)
+    process.exit(1)
   }
 }
 
 main().catch((error) => {
-  console.error(`Failed to start MCP server:`, error)
+  console.error('Failed to start MCP server:', error)
   process.exit(1)
 })

--- a/packages/auto-mcp-servers/src/index.ts
+++ b/packages/auto-mcp-servers/src/index.ts
@@ -1,3 +1,0 @@
-// Export servers
-export { autoDriveServer } from './auto-drive/index.js'
-export { autoExperiencesServer } from './auto-experiences/index.js'

--- a/packages/auto-mcp-servers/src/index.ts
+++ b/packages/auto-mcp-servers/src/index.ts
@@ -1,2 +1,3 @@
 // Export servers
 export { autoDriveServer } from './auto-drive/index.js'
+export { autoExperiencesServer } from './auto-experiences/index.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,7 +43,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-agents@workspace:packages/auto-agents":
+"@autonomys/auto-agents@npm:^1.4.18, @autonomys/auto-agents@workspace:packages/auto-agents":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-agents@workspace:packages/auto-agents"
   dependencies:
@@ -127,6 +127,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-mcp-servers@workspace:packages/auto-mcp-servers"
   dependencies:
+    "@autonomys/auto-agents": "npm:^1.4.18"
     "@autonomys/auto-drive": "npm:^1.4.18"
     "@modelcontextprotocol/sdk": "npm:^1.9.0"
     "@types/node": "npm:22.14.0"
@@ -135,6 +136,7 @@ __metadata:
     zod: "npm:^3.24.2"
   bin:
     auto-drive-server: ./dist/bin/auto-drive.js
+    auto-experiences-server: ./dist/bin/auto-experiences.js
     auto-mcp-servers: ./dist/bin/main.js
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Add Auto Experiences MCP Server

This PR adds a new MCP server for managing agent experiences, along with several improvements to the existing codebase.

## Key Changes

1. Added new Auto Experiences server with two main tools:
   - `save-experience`: Saves agent experience data to AutoDrive and updates the last experience CID
   - `retrieve-experience`: Retrieves agent experiences using their CID

2. Enhanced CID Manager functionality:
   - Made contract info optional with graceful fallback to local-only storage
   - Improved error handling and offline mode support
   - Refactored provider initialization logic

3. Infrastructure improvements:
   - Added new binary `auto-experiences-server` for standalone operation
   - Updated main server to support both Auto Drive and Auto Experiences
   - Enhanced error handling and logging across the codebase

4. Type safety improvements:
   - Replaced `any` types with proper TypeScript types
   - Added better type definitions for experience data
   - Improved error handling types

## Testing

- Tested with both Cursor MCP and Claude Desktop clients

