### PR TITLE
fix: express http requests handling

### DIFF
--- a/packages/utility/rpc/src/ws/server.ts
+++ b/packages/utility/rpc/src/ws/server.ts
@@ -27,6 +27,23 @@ export const createWsServer = ({
     ws.on('close', onClose)
   }
 
+  const wrapRequestListener = (
+    fn: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+  ) => {
+    return (req: http.IncomingMessage, res: http.ServerResponse) => {
+      if (req.method === 'POST' && req.url === '/ws') {
+        return
+      }
+      fn(req, res)
+    }
+  }
+
+  const listeners = httpServer.listeners('request') as http.RequestListener[]
+  listeners.forEach((listener) => {
+    httpServer.removeListener('request', listener)
+    httpServer.on('request', wrapRequestListener(listener))
+  })
+
   if (connectionAcceptance) {
     ws.on('request', connectionAcceptance)
   } else {


### PR DESCRIPTION
Previously, when the `ws` server was built on top of an express server all the routes declared in express were effectively wiped. 

Now the `onHttpRequest` callback only is executed over the route `/ws` allowing to wrap all the `'request'` callbacks ignoring the default handler in express that returns `Not Found (404)`