### PR TITLE
Fix missing wrap of RPC handler http request

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "npmClient": "yarn"
 }

--- a/packages/auto-agents/package.json
+++ b/packages/auto-agents/package.json
@@ -38,5 +38,5 @@
     "ts-jest": "^29.3.1",
     "typescript": "^5.8.3"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/auto-agents/package.json
+++ b/packages/auto-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-agents",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",
@@ -26,8 +26,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-dag-data": "^1.4.21",
-    "@autonomys/auto-drive": "^1.4.21",
+    "@autonomys/auto-dag-data": "^1.4.22",
+    "@autonomys/auto-drive": "^1.4.22",
     "ethers": "6.13.5"
   },
   "devDependencies": {

--- a/packages/auto-consensus/package.json
+++ b/packages/auto-consensus/package.json
@@ -35,5 +35,5 @@
     "ts-jest": "^29.3.1",
     "typescript": "^5.8.3"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/auto-consensus/package.json
+++ b/packages/auto-consensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-consensus",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-utils": "^1.4.21"
+    "@autonomys/auto-utils": "^1.4.22"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/auto-dag-data/package.json
+++ b/packages/auto-dag-data/package.json
@@ -52,5 +52,5 @@
     "protons": "^7.6.0",
     "protons-runtime": "^5.5.0"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/auto-dag-data/package.json
+++ b/packages/auto-dag-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-dag-data",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.4.21",
+    "@autonomys/asynchronous": "^1.4.22",
     "@ipld/dag-pb": "^4.1.3",
     "@peculiar/webcrypto": "^1.5.0",
     "@webbuf/blake3": "^3.0.26",

--- a/packages/auto-design-system/package.json
+++ b/packages/auto-design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-design-system",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.20",
+  "version": "1.4.22",
   "license": "MIT",
   "description": "Autonomys Design System",
   "type": "module",

--- a/packages/auto-design-system/package.json
+++ b/packages/auto-design-system/package.json
@@ -33,7 +33,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@autonomys/design-tokens": "workspace:*"
+    "@autonomys/design-tokens": "1.4.22"
   },
   "devDependencies": {
     "@babel/core": "^7.27.1",
@@ -74,5 +74,5 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -52,5 +52,5 @@
     "stream": "^0.0.3",
     "zod": "^3.24.2"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-drive",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,9 +42,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.4.21",
-    "@autonomys/auto-dag-data": "^1.4.21",
-    "@autonomys/auto-utils": "^1.4.21",
+    "@autonomys/asynchronous": "^1.4.22",
+    "@autonomys/auto-dag-data": "^1.4.22",
+    "@autonomys/auto-utils": "^1.4.22",
     "blockstore-core": "^5.0.2",
     "jszip": "^3.10.1",
     "mime-types": "^3.0.1",

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -40,5 +40,6 @@
     "@types/node": "22.14.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.8.3"
-  }
+  },
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-mcp-servers",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "description": "Autonomys Network MCP servers",
   "repository": {
     "type": "git",
@@ -31,8 +31,8 @@
     "server"
   ],
   "dependencies": {
-    "@autonomys/auto-agents": "^1.4.21",
-    "@autonomys/auto-drive": "^1.4.21",
+    "@autonomys/auto-agents": "^1.4.22",
+    "@autonomys/auto-drive": "^1.4.22",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "zod": "^3.24.2"
   },

--- a/packages/auto-utils/package.json
+++ b/packages/auto-utils/package.json
@@ -39,5 +39,5 @@
     "ts-jest": "^29.3.1",
     "typescript": "^5.8.3"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/auto-utils/package.json
+++ b/packages/auto-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-utils",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/packages/auto-xdm/package.json
+++ b/packages/auto-xdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-xdm",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,8 +25,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-consensus": "^1.4.21",
-    "@autonomys/auto-utils": "^1.4.21"
+    "@autonomys/auto-consensus": "^1.4.22",
+    "@autonomys/auto-utils": "^1.4.22"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/auto-xdm/package.json
+++ b/packages/auto-xdm/package.json
@@ -36,5 +36,5 @@
     "ts-jest": "^29.3.1",
     "typescript": "^5.8.3"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/utility/asynchronous/package.json
+++ b/packages/utility/asynchronous/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/asynchronous",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/utility/asynchronous/package.json
+++ b/packages/utility/asynchronous/package.json
@@ -29,5 +29,5 @@
     "ts-jest": "^29.3.1",
     "typescript": "^5.8.3"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/utility/contracts/package.json
+++ b/packages/utility/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/contracts",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/packages/utility/contracts/package.json
+++ b/packages/utility/contracts/package.json
@@ -33,5 +33,5 @@
   "dependencies": {
     "ethers": "6.13.5"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/utility/design-tokens/package.json
+++ b/packages/utility/design-tokens/package.json
@@ -45,5 +45,5 @@
     "rollup": "^4.1.4",
     "typescript": "^5.3.3"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/utility/design-tokens/package.json
+++ b/packages/utility/design-tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/design-tokens",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.18",
+  "version": "1.4.22",
   "description": "Auto Design Tokens",
   "type": "module",
   "license": "MIT",

--- a/packages/utility/file-caching/package.json
+++ b/packages/utility/file-caching/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/file-caching",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -45,9 +45,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.4.21",
-    "@autonomys/auto-dag-data": "^1.4.21",
-    "@autonomys/auto-utils": "^1.4.21",
+    "@autonomys/asynchronous": "^1.4.22",
+    "@autonomys/auto-dag-data": "^1.4.22",
+    "@autonomys/auto-utils": "^1.4.22",
     "@keyvhq/sqlite": "^2.1.7",
     "cache-manager": "^6.4.2",
     "jszip": "^3.10.1",

--- a/packages/utility/file-caching/package.json
+++ b/packages/utility/file-caching/package.json
@@ -58,5 +58,5 @@
     "uuid": "^11.1.0",
     "zod": "^3.24.2"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/utility/rpc/__test__/rpc/typed.spec.ts
+++ b/packages/utility/rpc/__test__/rpc/typed.spec.ts
@@ -186,8 +186,8 @@ describe('rpc/definition', () => {
     expect(mock.mock.calls[0][0]).toEqual('test')
   })
 
-  it('should handle a fetch http request', async () => {
-    const client = createHttpClient(`http://localhost:${TEST_PORT}`)
+  it('should handle a fetch http request with route /ws', async () => {
+    const client = createHttpClient(`http://localhost:${TEST_PORT}/ws`)
     const result = await client.test({ name: 'test' })
     expect(result).toEqual({ name: 'test' })
   })

--- a/packages/utility/rpc/package.json
+++ b/packages/utility/rpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/rpc",
   "packageManager": "yarn@4.7.0",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "repository": {
     "type": "git",
     "url": "https://github.com/autonomys/auto-sdk"

--- a/packages/utility/rpc/package.json
+++ b/packages/utility/rpc/package.json
@@ -41,5 +41,5 @@
     "ts-jest": "^29.3.1",
     "typescript": "^5.8.3"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/utility/rpc/src/rpc/api/definition.ts
+++ b/packages/utility/rpc/src/rpc/api/definition.ts
@@ -139,7 +139,7 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
       return [
         method,
         async (params: Parameters<DefinitionTypeOutput<typeof handler.params>>[0]) => {
-          const result = await fetch(`${baseUrl}/${method}`, {
+          const result = await fetch(`${baseUrl}`, {
             method: 'POST',
             body: JSON.stringify({
               jsonrpc: '2.0',

--- a/packages/utility/rpc/src/ws/server.ts
+++ b/packages/utility/rpc/src/ws/server.ts
@@ -87,7 +87,11 @@ export const createWsServer = ({
   }
 
   const onHttpRequest = (fn: (req: http.IncomingMessage, res: http.ServerResponse) => void) => {
-    httpServer.on('request', fn)
+    httpServer.on('request', (req, res) => {
+      if (req.method === 'POST' && req.url === '/ws') {
+        fn(req, res)
+      }
+    })
   }
 
   return {

--- a/packages/utility/user-session/package.json
+++ b/packages/utility/user-session/package.json
@@ -36,5 +36,5 @@
     "@autonomys/auto-drive": "^1.4.22",
     "ethers": "6.13.5"
   },
-  "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"
+  "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"
 }

--- a/packages/utility/user-session/package.json
+++ b/packages/utility/user-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/user-session",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -31,9 +31,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.4.21",
-    "@autonomys/auto-dag-data": "^1.4.21",
-    "@autonomys/auto-drive": "^1.4.21",
+    "@autonomys/asynchronous": "^1.4.22",
+    "@autonomys/auto-dag-data": "^1.4.22",
+    "@autonomys/auto-drive": "^1.4.22",
     "ethers": "6.13.5"
   },
   "gitHead": "d921e7787652cf71e47a9785303a41c7f4f8d0fd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,7 +101,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-design-system@workspace:packages/auto-design-system"
   dependencies:
-    "@autonomys/design-tokens": "workspace:*"
+    "@autonomys/design-tokens": "npm:1.4.22"
     "@babel/core": "npm:^7.27.1"
     "@babel/preset-env": "npm:^7.27.2"
     "@babel/preset-react": "npm:^7.27.1"
@@ -246,7 +246,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/design-tokens@workspace:*, @autonomys/design-tokens@workspace:packages/utility/design-tokens":
+"@autonomys/design-tokens@npm:1.4.22, @autonomys/design-tokens@workspace:packages/utility/design-tokens":
   version: 0.0.0-use.local
   resolution: "@autonomys/design-tokens@workspace:packages/utility/design-tokens"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@autonomys/asynchronous@npm:^1.4.21, @autonomys/asynchronous@workspace:packages/utility/asynchronous":
+"@autonomys/asynchronous@npm:^1.4.22, @autonomys/asynchronous@workspace:packages/utility/asynchronous":
   version: 0.0.0-use.local
   resolution: "@autonomys/asynchronous@workspace:packages/utility/asynchronous"
   dependencies:
@@ -43,12 +43,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-agents@npm:^1.4.21, @autonomys/auto-agents@workspace:packages/auto-agents":
+"@autonomys/auto-agents@npm:^1.4.22, @autonomys/auto-agents@workspace:packages/auto-agents":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-agents@workspace:packages/auto-agents"
   dependencies:
-    "@autonomys/auto-dag-data": "npm:^1.4.21"
-    "@autonomys/auto-drive": "npm:^1.4.21"
+    "@autonomys/auto-dag-data": "npm:^1.4.22"
+    "@autonomys/auto-drive": "npm:^1.4.22"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     ethers: "npm:6.13.5"
@@ -59,11 +59,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-consensus@npm:^1.4.21, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
+"@autonomys/auto-consensus@npm:^1.4.22, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-consensus@workspace:packages/auto-consensus"
   dependencies:
-    "@autonomys/auto-utils": "npm:^1.4.21"
+    "@autonomys/auto-utils": "npm:^1.4.22"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     jest: "npm:^29.7.0"
@@ -73,11 +73,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-dag-data@npm:^1.4.21, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
+"@autonomys/auto-dag-data@npm:^1.4.22, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-dag-data@workspace:packages/auto-dag-data"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.4.21"
+    "@autonomys/asynchronous": "npm:^1.4.22"
     "@ipld/dag-pb": "npm:^4.1.3"
     "@peculiar/webcrypto": "npm:^1.5.0"
     "@types/jest": "npm:^29.5.14"
@@ -141,13 +141,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-drive@npm:^1.4.21, @autonomys/auto-drive@workspace:*, @autonomys/auto-drive@workspace:packages/auto-drive":
+"@autonomys/auto-drive@npm:^1.4.22, @autonomys/auto-drive@workspace:*, @autonomys/auto-drive@workspace:packages/auto-drive":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-drive@workspace:packages/auto-drive"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.4.21"
-    "@autonomys/auto-dag-data": "npm:^1.4.21"
-    "@autonomys/auto-utils": "npm:^1.4.21"
+    "@autonomys/asynchronous": "npm:^1.4.22"
+    "@autonomys/auto-dag-data": "npm:^1.4.22"
+    "@autonomys/auto-utils": "npm:^1.4.22"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"
     "@rollup/plugin-json": "npm:^6.1.0"
@@ -171,8 +171,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-mcp-servers@workspace:packages/auto-mcp-servers"
   dependencies:
-    "@autonomys/auto-agents": "npm:^1.4.21"
-    "@autonomys/auto-drive": "npm:^1.4.21"
+    "@autonomys/auto-agents": "npm:^1.4.22"
+    "@autonomys/auto-drive": "npm:^1.4.22"
     "@modelcontextprotocol/sdk": "npm:^1.9.0"
     "@types/node": "npm:22.14.0"
     ts-node: "npm:^10.9.1"
@@ -201,7 +201,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-utils@npm:^1.4.21, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
+"@autonomys/auto-utils@npm:^1.4.22, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-utils@workspace:packages/auto-utils"
   dependencies:
@@ -223,8 +223,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-xdm@workspace:packages/auto-xdm"
   dependencies:
-    "@autonomys/auto-consensus": "npm:^1.4.21"
-    "@autonomys/auto-utils": "npm:^1.4.21"
+    "@autonomys/auto-consensus": "npm:^1.4.22"
+    "@autonomys/auto-utils": "npm:^1.4.22"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     jest: "npm:^29.7.0"
@@ -269,9 +269,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/file-caching@workspace:packages/utility/file-caching"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.4.21"
-    "@autonomys/auto-dag-data": "npm:^1.4.21"
-    "@autonomys/auto-utils": "npm:^1.4.21"
+    "@autonomys/asynchronous": "npm:^1.4.22"
+    "@autonomys/auto-dag-data": "npm:^1.4.22"
+    "@autonomys/auto-utils": "npm:^1.4.22"
     "@keyvhq/sqlite": "npm:^2.1.7"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"
@@ -312,9 +312,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/user-session@workspace:packages/utility/user-session"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.4.21"
-    "@autonomys/auto-dag-data": "npm:^1.4.21"
-    "@autonomys/auto-drive": "npm:^1.4.21"
+    "@autonomys/asynchronous": "npm:^1.4.22"
+    "@autonomys/auto-dag-data": "npm:^1.4.22"
+    "@autonomys/auto-drive": "npm:^1.4.22"
     eslint: "npm:^9.25.1"
     ethers: "npm:6.13.5"
     prettier: "npm:^3.5.3"


### PR DESCRIPTION
The handler for RPC http request should've ensured that is `method=POST` and `route=/ws`