### PR TITLE
feat: redirect to public instances for downloads

### DIFF
--- a/packages/auto-drive/src/api/calls/download.ts
+++ b/packages/auto-drive/src/api/calls/download.ts
@@ -7,7 +7,7 @@ export const downloadObject = async (
 ): Promise<ReadableStream<Uint8Array>> => {
   const ignoreBackendEncoding = query.ignoreBackendEncoding ?? true
 
-  const response = await api.sendRequest(
+  const response = await api.sendDownloadRequest(
     `/objects/${query.cid}/download?ignoreEncoding=${ignoreBackendEncoding}`,
     {
       method: 'GET',
@@ -26,5 +26,5 @@ export const downloadObject = async (
 }
 
 export const publicDownloadUrl = (api: AutoDriveApiHandler, cid: string): string => {
-  return `${api.baseUrl}/objects/${cid}/public`
+  return `${api.downloadBaseUrl}/objects/${cid}/public`
 }

--- a/packages/auto-drive/src/api/calls/read.ts
+++ b/packages/auto-drive/src/api/calls/read.ts
@@ -16,7 +16,7 @@ export const getRoots = async (
   api: AutoDriveApiHandler,
   query: ArgsWithPagination<{ scope: Scope }>,
 ): Promise<PaginatedResult<ObjectSummary>> => {
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     `/objects/roots?scope=${query.scope}&limit=${query.limit}&offset=${query.offset}`,
     {
       method: 'GET',
@@ -45,7 +45,7 @@ export const getSharedWithMe = async (
   api: AutoDriveApiHandler,
   query: ArgsWithPagination,
 ): Promise<PaginatedResult<ObjectSummary>> => {
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     `/objects/roots/shared?limit=${query.limit}&offset=${query.offset}`,
     {
       method: 'GET',
@@ -63,7 +63,7 @@ export const searchByNameOrCID = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ value: string; scope: Scope }>,
 ): Promise<ObjectSearchResult[]> => {
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     `/objects/search?cid=${encodeURIComponent(query.value)}&scope=${query.scope}`,
     {
       method: 'GET',
@@ -92,7 +92,7 @@ export const getDeleted = async (
   api: AutoDriveApiHandler,
   query: ArgsWithPagination,
 ): Promise<PaginatedResult<ObjectSummary>> => {
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     `/objects/roots/deleted?limit=${query.limit}&offset=${query.offset}`,
     {
       method: 'GET',
@@ -121,7 +121,7 @@ export const getObject = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string }>,
 ): Promise<ObjectInformation> => {
-  const response = await api.sendRequest(`/objects/${query.cid}`, {
+  const response = await api.sendAPIRequest(`/objects/${query.cid}`, {
     method: 'GET',
   })
 
@@ -146,7 +146,7 @@ export const getObjectSummary = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string }>,
 ): Promise<ObjectSummary> => {
-  const response = await api.sendRequest(`/objects/${query.cid}/summary`, {
+  const response = await api.sendAPIRequest(`/objects/${query.cid}/summary`, {
     method: 'GET',
   })
 
@@ -173,7 +173,7 @@ export const getObjectUploadStatus = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string }>,
 ): Promise<ObjectInformation['uploadStatus']> => {
-  const response = await api.sendRequest(`/objects/${query.cid}/status`, {
+  const response = await api.sendAPIRequest(`/objects/${query.cid}/status`, {
     method: 'GET',
   })
 
@@ -200,7 +200,7 @@ export const getObjectOwners = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string }>,
 ): Promise<ObjectInformation['owners']> => {
-  const response = await api.sendRequest(`/objects/${query.cid}/owners`, {
+  const response = await api.sendAPIRequest(`/objects/${query.cid}/owners`, {
     method: 'GET',
   })
 
@@ -227,7 +227,7 @@ export const getObjectMetadata = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string }>,
 ): Promise<ObjectInformation['metadata']> => {
-  const response = await api.sendRequest(`/objects/${query.cid}/metadata`, {
+  const response = await api.sendAPIRequest(`/objects/${query.cid}/metadata`, {
     method: 'GET',
   })
 
@@ -246,7 +246,7 @@ export const getObjectMetadata = async (
  * @throws {Error} - Throws an error if the request fails.
  */
 export const getMe = async (api: AutoDriveApiHandler): Promise<UserInfo> => {
-  const response = await api.sendRequest('@me', {
+  const response = await api.sendAPIRequest('@me', {
     method: 'GET',
   })
   if (!response.ok) {

--- a/packages/auto-drive/src/api/calls/upload.ts
+++ b/packages/auto-drive/src/api/calls/upload.ts
@@ -31,7 +31,7 @@ export const createFileUpload = async (
     uploadOptions: FileUploadOptions | null
   }>,
 ): Promise<FileUpload> => {
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     '/uploads/file',
     {
       method: 'POST',
@@ -66,7 +66,7 @@ export const createFolderUpload = async (
     uploadOptions = {},
   }: ArgsWithoutPagination<{ fileTree: FolderTree; uploadOptions?: FileUploadOptions }>,
 ): Promise<FolderUpload> => {
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     '/uploads/folder',
     {
       method: 'POST',
@@ -113,7 +113,7 @@ export const createFileUploadWithinFolderUpload = async (
     uploadOptions: FileUploadOptions
   }>,
 ): Promise<FileUpload> => {
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     `/uploads/folder/${uploadId}/file`,
     {
       method: 'POST',
@@ -159,7 +159,7 @@ export const uploadFileChunk = async (
   formData.append('file', new Blob([chunk]))
   formData.append('index', index.toString())
 
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     `/uploads/file/${uploadId}/chunk`,
     {
       method: 'POST',
@@ -190,7 +190,7 @@ export const completeUpload = async (
   api: AutoDriveApiHandler,
   { uploadId }: ArgsWithoutPagination<{ uploadId: string }>,
 ): Promise<CompleteUploadResponse> => {
-  const response = await api.sendRequest(`/uploads/${uploadId}/complete`, {
+  const response = await api.sendAPIRequest(`/uploads/${uploadId}/complete`, {
     method: 'POST',
   })
 

--- a/packages/auto-drive/src/api/calls/write.ts
+++ b/packages/auto-drive/src/api/calls/write.ts
@@ -17,7 +17,7 @@ export const shareObject = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string; publicId: string }>,
 ) => {
-  const response = await api.sendRequest(
+  const response = await api.sendAPIRequest(
     `/objects/${query.cid}/share`,
     {
       method: 'POST',
@@ -51,7 +51,7 @@ export const markObjectAsDeleted = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string }>,
 ): Promise<void> => {
-  const response = await api.sendRequest(`/objects/${query.cid}/delete`, {
+  const response = await api.sendAPIRequest(`/objects/${query.cid}/delete`, {
     method: 'POST',
   })
 
@@ -76,7 +76,7 @@ export const restoreObject = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string }>,
 ): Promise<void> => {
-  const response = await api.sendRequest(`/objects/${query.cid}/restore`, {
+  const response = await api.sendAPIRequest(`/objects/${query.cid}/restore`, {
     method: 'POST',
   })
 
@@ -103,7 +103,7 @@ export const publishObject = async (
   api: AutoDriveApiHandler,
   query: ArgsWithoutPagination<{ cid: string }>,
 ): Promise<{ result: string }> => {
-  const response = await api.sendRequest(`/objects/${query.cid}/publish`, {
+  const response = await api.sendAPIRequest(`/objects/${query.cid}/publish`, {
     method: 'POST',
   })
 

--- a/packages/auto-drive/src/api/handler.ts
+++ b/packages/auto-drive/src/api/handler.ts
@@ -41,7 +41,7 @@ export const createApiRequestHandler = ({
 
   const api = {
     sendAPIRequest: createSendRequest(baseUrl, provider, apiKey),
-    sendDownloadServiceRequest: createSendRequest(downloadBaseUrl, provider, apiKey),
+    sendDownloadRequest: createSendRequest(downloadBaseUrl, provider, apiKey),
     downloadBaseUrl,
     baseUrl,
   }

--- a/packages/auto-drive/src/api/handler.ts
+++ b/packages/auto-drive/src/api/handler.ts
@@ -1,6 +1,25 @@
 import { version } from '../package'
-import { getNetworkUrl } from './networks'
-import { AutoDriveApiHandler, ConnectionOptions } from './types'
+import { getDownloadServiceUrl, getNetworkUrl } from './networks'
+import { AuthProvider, AutoDriveApiHandler, ConnectionOptions } from './types'
+
+const createSendRequest =
+  (baseUrl: string, provider: AuthProvider, apiKey: string) =>
+  async (relativeUrl: string, request: Partial<Request>, body?: BodyInit) => {
+    const headers = new Headers({
+      ...Object.fromEntries(request.headers?.entries() || []),
+      'x-auth-provider': provider,
+      Authorization: `Bearer ${apiKey}`,
+      'x-auto-sdk-version': version,
+      'User-Agent': `AutoDrive/${version}`,
+    })
+    const fullRequest = {
+      ...request,
+      headers: new Headers(headers),
+      body,
+    }
+
+    return fetch(`${baseUrl}${relativeUrl}`, fullRequest)
+  }
 
 export const createApiRequestHandler = ({
   provider = 'apikey',
@@ -9,27 +28,21 @@ export const createApiRequestHandler = ({
   network,
 }: ConnectionOptions): AutoDriveApiHandler => {
   const baseUrl = !network ? url : getNetworkUrl(network)
+  const downloadBaseUrl = !network ? url : getDownloadServiceUrl(network)
   if (!baseUrl) {
     throw new Error('No base URL provided')
   }
+  if (!downloadBaseUrl) {
+    throw new Error('No download base URL provided')
+  }
+  if (!apiKey) {
+    throw new Error('No API key provided')
+  }
 
   const api = {
-    sendRequest: async (relativeUrl: string, request: Partial<Request>, body?: BodyInit) => {
-      const headers = new Headers({
-        ...Object.fromEntries(request.headers?.entries() || []),
-        'x-auth-provider': provider,
-        Authorization: `Bearer ${apiKey}`,
-        'x-auto-sdk-version': version,
-        'User-Agent': `AutoDrive/${version}`,
-      })
-      const fullRequest = {
-        ...request,
-        headers: new Headers(headers),
-        body,
-      }
-
-      return fetch(`${baseUrl}${relativeUrl}`, fullRequest)
-    },
+    sendAPIRequest: createSendRequest(baseUrl, provider, apiKey),
+    sendDownloadServiceRequest: createSendRequest(downloadBaseUrl, provider, apiKey),
+    downloadBaseUrl,
     baseUrl,
   }
 

--- a/packages/auto-drive/src/api/networks.ts
+++ b/packages/auto-drive/src/api/networks.ts
@@ -1,16 +1,29 @@
 import { NetworkId } from '@autonomys/auto-utils'
 
-export type AutoDriveNetwork = keyof typeof networks
+export type AutoDriveNetwork = keyof typeof apiEndpoints
 
-export const networks = {
+export const apiEndpoints = {
   [NetworkId.TAURUS]: 'https://demo.auto-drive.autonomys.xyz/api',
   [NetworkId.MAINNET]: 'https://mainnet.auto-drive.autonomys.xyz/api',
 } satisfies Partial<Record<NetworkId, string>>
 
+export const downloadServiceEndpoints = {
+  [NetworkId.TAURUS]: 'https://public.taurus.auto-drive.autonomys.xyz/api',
+  [NetworkId.MAINNET]: 'https://public.auto-drive.autonomys.xyz/api',
+} satisfies Partial<Record<NetworkId, string>>
+
 export const getNetworkUrl = (networkId: AutoDriveNetwork) => {
-  if (!networks[networkId]) {
+  if (!apiEndpoints[networkId]) {
     throw new Error(`Network ${networkId} not found`)
   }
 
-  return networks[networkId]
+  return apiEndpoints[networkId]
+}
+
+export const getDownloadServiceUrl = (networkId: AutoDriveNetwork) => {
+  if (!downloadServiceEndpoints[networkId]) {
+    throw new Error(`Network ${networkId} not found`)
+  }
+
+  return downloadServiceEndpoints[networkId]
 }

--- a/packages/auto-drive/src/api/types.ts
+++ b/packages/auto-drive/src/api/types.ts
@@ -171,11 +171,17 @@ export interface AutoDriveApi extends AutoDriveApiHandler {
 }
 
 export interface AutoDriveApiHandler {
-  sendRequest: (
+  sendAPIRequest: (
     relativeUrl: string,
     request: Partial<Request>,
     body?: BodyInit,
   ) => Promise<Response>
+  sendDownloadRequest: (
+    relativeUrl: string,
+    request: Partial<Request>,
+    body?: BodyInit,
+  ) => Promise<Response>
+  downloadBaseUrl: string
   baseUrl: string
 }
 

--- a/packages/auto-drive/src/api/wrappers.ts
+++ b/packages/auto-drive/src/api/wrappers.ts
@@ -360,7 +360,7 @@ export const createApiInterface = (api: AutoDriveApiHandler): AutoDriveApi => {
     getMyFiles,
     searchByNameOrCIDInMyFiles,
     searchByNameOrCID,
-    sendRequest: api.sendRequest,
+    sendAPIRequest: api.sendAPIRequest,
     baseUrl: api.baseUrl,
   }
 }

--- a/packages/auto-drive/src/api/wrappers.ts
+++ b/packages/auto-drive/src/api/wrappers.ts
@@ -361,6 +361,8 @@ export const createApiInterface = (api: AutoDriveApiHandler): AutoDriveApi => {
     searchByNameOrCIDInMyFiles,
     searchByNameOrCID,
     sendAPIRequest: api.sendAPIRequest,
+    sendDownloadRequest: api.sendDownloadRequest,
     baseUrl: api.baseUrl,
+    downloadBaseUrl: api.downloadBaseUrl,
   }
 }


### PR DESCRIPTION
Similarly to https://github.com/autonomys/auto-drive/pull/366 redirect all downloads through public instances making the cache hit much more times. 