### PR TITLE
fix(auto-mcp-servers): remove cross-dependency on env vars

### DIFF
--- a/packages/auto-mcp-servers/src/bin/main.ts
+++ b/packages/auto-mcp-servers/src/bin/main.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { autoDriveServer } from '../auto-drive/index.js'
-import { autoExperiencesServer } from '../auto-experiences/index.js'
 
 const showHelp = () => {
   console.error(`
@@ -38,14 +36,18 @@ const main = async () => {
 
   try {
     switch (serverName) {
-      case 'auto-drive':
+      case 'auto-drive': {
         console.error('Starting Auto Drive MCP server...')
+        const { autoDriveServer } = await import('../auto-drive/index.js')
         await autoDriveServer.connect(transport)
         break
-      case 'auto-experiences':
+      }
+      case 'auto-experiences': {
         console.error('Starting Auto Experiences MCP server...')
+        const { autoExperiencesServer } = await import('../auto-experiences/index.js')
         await autoExperiencesServer.connect(transport)
         break
+      }
       case 'help':
       case '--help':
       case '-h':


### PR DESCRIPTION
## Fix: Remove unwanted dependency between auto-drive and auto-experiences MCP servers

### Problem
The `auto-drive` MCP server was failing to start due to an unwanted dependency on environment variables from `auto-experiences` (`AGENT_PATH`, `AGENT_NAME`, etc.). This occurred because the main entry point was statically importing both servers, causing all modules to be loaded and executed regardless of which server was requested.

### Solution
- Changed static imports to dynamic imports in `src/bin/main.ts`
- Each server module is now only loaded when specifically requested

### Changes
- `packages/auto-mcp-servers/src/bin/main.ts`: Replace static imports with dynamic imports

### Testing
- `auto-drive-server` now starts without requiring `AGENT_PATH` environment variable
- `auto-experiences-server` continues to work as expected with its required environment variables
