### PR TITLE
fix: `Cache.has` method was not returning a boolean but throwing if failing

### DIFF
--- a/packages/utility/file-caching/src/fileCache.ts
+++ b/packages/utility/file-caching/src/fileCache.ts
@@ -55,9 +55,12 @@ export const createFileCache = (config: BaseCacheConfig) => {
     }
   }
 
-  const has = async (cid: string) => {
+  const has = async (cid: string): Promise<boolean> => {
     const path = cidToFilePath(cid)
-    return fsPromises.access(path, fs.constants.F_OK)
+    return fsPromises
+      .access(path, fs.constants.F_OK)
+      .then(() => true)
+      .catch(() => false)
   }
 
   const set = async (cid: string, fileResponse: FileResponse) => {


### PR DESCRIPTION
Problem: 

`Cache.has` method was not returning a boolean but throwing if failing

Solution: 

Make `Cache.has` method return boolean by wrapping promise in then/catch structure