### PR TITLE
fix: downloads should be perfomed in raw mode

### DIFF
--- a/packages/auto-files/src/api.ts
+++ b/packages/auto-files/src/api.ts
@@ -122,8 +122,12 @@ export const createAutoFilesApi = (baseUrl: string, apiSecret: string) => {
     return status.isCached
   }
 
-  const getFileFromCache = async (cid: string): Promise<Readable> => {
-    const response = await authFetch(`${baseUrl}/files/${cid}`)
+  const getFileFromCache = async (
+    cid: string,
+    options: { raw?: boolean } = {},
+  ): Promise<Readable> => {
+    const raw = options.raw ?? false
+    const response = await authFetch(`${baseUrl}/files/${cid}?raw=${raw}`)
     if (!response.ok) {
       throw new Error(`Error fetching file from cache: ${response.status} ${response.statusText}`)
     }
@@ -154,7 +158,7 @@ export const createAutoFilesApi = (baseUrl: string, apiSecret: string) => {
     } = {},
   ) => {
     if (!ignoreCache && (await isFileCached(cid))) {
-      return getFileFromCache(cid)
+      return getFileFromCache(cid, { raw: true })
     }
 
     const file = await getChunkedFile(cid, {


### PR DESCRIPTION
*Problem:*

Auto-Drive already handles decompression/decryption by its own, so the download should be performed in raw mode.