### PR TITLE
feat: improve type infer

### DIFF
--- a/packages/utility/rpc/src/rpc/api/definition.ts
+++ b/packages/utility/rpc/src/rpc/api/definition.ts
@@ -19,11 +19,9 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
   ): {
     api: Client
     close: () => void
-    onNotification: (
-      notificationName: keyof S['notifications'],
-      handler: (
-        params: DefinitionTypeOutput<S['notifications'][keyof S['notifications']]['content']>,
-      ) => void,
+    onNotification: <T extends keyof S['notifications']>(
+      notificationName: T,
+      handler: (params: DefinitionTypeOutput<S['notifications'][T]['content']>) => void,
     ) => void
   } => {
     const client = createRpcClient(clientParams)


### PR DESCRIPTION
**Problem:**

When two notifications are declared in the same rpc definitions the type received as content of notifications is the merge of the two defined notifications content type.

**Solution:**

Avoid types to merge