### PR TITLE
feat: enable passing http options to HttpClient & methods

### DIFF
--- a/packages/utility/rpc/src/rpc/api/definition.ts
+++ b/packages/utility/rpc/src/rpc/api/definition.ts
@@ -9,6 +9,7 @@ import {
   ApiServerHandlers,
   ApiServerNotifications,
   DefinitionTypeOutput,
+  HttpClientOptions,
   HttpClientType,
   isZodType,
   WsClientType,
@@ -132,14 +133,17 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
     }
   }
 
-  const createHttpClient = <Client extends HttpClientType<S>>(baseUrl: string) => {
+  const createHttpClient = <Client extends HttpClientType<S>>(
+    baseUrl: string,
+    clientOptions?: HttpClientOptions,
+  ) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const apiMethods = Object.entries(serverDefinition.methods).map(([method, handler]) => {
       return [
         method,
         async (
           params: Parameters<DefinitionTypeOutput<typeof handler.params>>[0],
-          headers?: Record<string, string>,
+          options?: HttpClientOptions,
         ) => {
           const result = await fetch(`${baseUrl}`, {
             method: 'POST',
@@ -151,7 +155,8 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
             }),
             headers: {
               'Content-Type': 'application/json',
-              ...headers,
+              ...clientOptions?.headers,
+              ...options?.headers,
             },
           })
 

--- a/packages/utility/rpc/src/rpc/api/definition.ts
+++ b/packages/utility/rpc/src/rpc/api/definition.ts
@@ -5,16 +5,17 @@ import { createRpcServer } from '../server'
 import { Message, MessageQuery, RpcParams, TypedRpcNotificationHandler } from '../types'
 import { RpcError } from '../utils'
 import {
-  ApiClientType,
   ApiDefinition,
   ApiServerHandlers,
   ApiServerNotifications,
   DefinitionTypeOutput,
+  HttpClientType,
   isZodType,
+  WsClientType,
 } from './typing'
 
 export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S) => {
-  const createClient = <Client extends ApiClientType<S>>(
+  const createClient = <Client extends WsClientType<S>>(
     clientParams: Parameters<typeof createRpcClient>[0],
   ): {
     api: Client
@@ -131,12 +132,15 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
     }
   }
 
-  const createHttpClient = <Client extends ApiClientType<S>>(baseUrl: string) => {
+  const createHttpClient = <Client extends HttpClientType<S>>(baseUrl: string) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const apiMethods = Object.entries(serverDefinition.methods).map(([method, handler]) => {
       return [
         method,
-        async (params: Parameters<DefinitionTypeOutput<typeof handler.params>>[0]) => {
+        async (
+          params: Parameters<DefinitionTypeOutput<typeof handler.params>>[0],
+          headers?: Record<string, string>,
+        ) => {
           const result = await fetch(`${baseUrl}`, {
             method: 'POST',
             body: JSON.stringify({
@@ -145,6 +149,10 @@ export const createApiDefinition = <S extends ApiDefinition>(serverDefinition: S
               params,
               id: randomId(),
             }),
+            headers: {
+              'Content-Type': 'application/json',
+              ...headers,
+            },
           })
 
           if (!result.ok) {

--- a/packages/utility/rpc/src/rpc/api/typing.ts
+++ b/packages/utility/rpc/src/rpc/api/typing.ts
@@ -32,9 +32,20 @@ export type ApiDefinition = {
   notifications: Record<string, MessageDefinition>
 }
 
-export type ApiClientType<S extends ApiDefinition> = {
+export type HttpClientOptions = {
+  headers?: Record<string, string>
+}
+
+export type WsClientType<S extends ApiDefinition> = {
   [K in keyof S['methods']]: (
     params: DefinitionTypeOutput<S['methods'][K]['params']>,
+  ) => Promise<DefinitionTypeOutput<S['methods'][K]['returns']>>
+}
+
+export type HttpClientType<S extends ApiDefinition> = {
+  [K in keyof S['methods']]: (
+    params: DefinitionTypeOutput<S['methods'][K]['params']>,
+    options?: HttpClientOptions,
   ) => Promise<DefinitionTypeOutput<S['methods'][K]['returns']>>
 }
 


### PR DESCRIPTION
Sometimes RPC servers might require to pass additional headers (e.g `Authorization` header for auth) for covering this PR separates the ApiClient type into WsClient w/o `httpOpts` and HttpClient that accepts both HttpOptions for the whole client and for each method, having a bigger priority the method options that the client options.

