### PR TITLE
chore: v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,11 +218,29 @@
 - Chore v1.5.2 ([#431](https://github.com/autonomys/auto-sdk/pull/431)) [@clostao](https://github.com/clostao)
 
 
+## [1.5.5] - 2025-07-02
+
+### Features
+
+- add headDomainNumber function to retrieve latest block number for a specific domain ([#440](https://github.com/autonomys/auto-sdk/pull/440)) [@jfrank-summit](https://github.com/jfrank-summit)
+- add storage fee refund to pending withdrawals ([#439](https://github.com/autonomys/auto-sdk/pull/439)) [@jfrank-summit](https://github.com/jfrank-summit)
+
+
 ## [Unreleased]
 
 Future changes will appear here.
 
-## [1.4.30] - 2025-05-14
+### [1.5.4] - 2025-07-01
+
+### Features
+
+- enable passing http options to HttpClient & methods ([#438](https://github.com/autonomys/auto-sdk/pull/438)) [@clostao](https://github.com/clostao)
+
+### Chores
+
+- v1.5.3 ([#437](https://github.com/autonomys/auto-sdk/pull/437)) [@clostao](https://github.com/clostao)
+
+# [1.4.30] - 2025-05-14
 
 No changes in this version.
 

--- a/examples/auto-drive-create-next-app/package.json
+++ b/examples/auto-drive-create-next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-next-app",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/next/package-lock.json
+++ b/examples/next/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next",
-      "version": "1.5.3",
+      "version": "1.5.5",
       "dependencies": {
         "next": "14.2.4",
         "react": "^18",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-sdk-next-example",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "private": true,
   "license": "MIT",
   "packageManager": "yarn@4.2.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "npmClient": "yarn"
 }

--- a/packages/auto-agents/package.json
+++ b/packages/auto-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-agents",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",
@@ -26,8 +26,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-dag-data": "^1.5.3",
-    "@autonomys/auto-drive": "^1.5.3",
+    "@autonomys/auto-dag-data": "^1.5.5",
+    "@autonomys/auto-drive": "^1.5.5",
     "ethers": "6.13.5"
   },
   "devDependencies": {

--- a/packages/auto-consensus/package.json
+++ b/packages/auto-consensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-consensus",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-utils": "^1.5.3"
+    "@autonomys/auto-utils": "^1.5.5"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/auto-dag-data/package.json
+++ b/packages/auto-dag-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-dag-data",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.5.3",
+    "@autonomys/asynchronous": "^1.5.5",
     "@ipld/dag-pb": "^4.1.3",
     "@peculiar/webcrypto": "^1.5.0",
     "@webbuf/blake3": "^3.0.26",

--- a/packages/auto-design-system/package.json
+++ b/packages/auto-design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-design-system",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "description": "Autonomys Design System",
   "type": "module",
@@ -34,7 +34,7 @@
     "shadcn": "npx shadcn-ui@latest add"
   },
   "dependencies": {
-    "@autonomys/design-tokens": "^1.5.3",
+    "@autonomys/design-tokens": "^1.5.5",
     "@floating-ui/react": "^0.27.8",
     "@headlessui/react": "^2.2.3",
     "@heroicons/react": "^2.2.0",

--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-drive",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,9 +42,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.5.3",
-    "@autonomys/auto-dag-data": "^1.5.3",
-    "@autonomys/auto-utils": "^1.5.3",
+    "@autonomys/asynchronous": "^1.5.5",
+    "@autonomys/auto-dag-data": "^1.5.5",
+    "@autonomys/auto-utils": "^1.5.5",
     "blockstore-core": "^5.0.2",
     "jszip": "^3.10.1",
     "mime-types": "^3.0.1",

--- a/packages/auto-files/package.json
+++ b/packages/auto-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-files",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "packageManager": "yarn@4.7.0",
   "scripts": {
     "build": "tsc"
@@ -21,6 +21,6 @@
     }
   },
   "dependencies": {
-    "@autonomys/auto-drive": "^1.5.3"
+    "@autonomys/auto-drive": "^1.5.5"
   }
 }

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-mcp-servers",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "description": "Autonomys Network MCP servers",
   "repository": {
     "type": "git",
@@ -31,8 +31,8 @@
     "server"
   ],
   "dependencies": {
-    "@autonomys/auto-agents": "^1.5.3",
-    "@autonomys/auto-drive": "^1.5.3",
+    "@autonomys/auto-agents": "^1.5.5",
+    "@autonomys/auto-drive": "^1.5.5",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "zod": "^3.24.2"
   },

--- a/packages/auto-utils/package.json
+++ b/packages/auto-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-utils",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/packages/auto-xdm/package.json
+++ b/packages/auto-xdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-xdm",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,8 +25,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-consensus": "^1.5.3",
-    "@autonomys/auto-utils": "^1.5.3"
+    "@autonomys/auto-consensus": "^1.5.5",
+    "@autonomys/auto-utils": "^1.5.5"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/utility/asynchronous/package.json
+++ b/packages/utility/asynchronous/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/asynchronous",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/utility/contracts/package.json
+++ b/packages/utility/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/contracts",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/packages/utility/design-tokens/package.json
+++ b/packages/utility/design-tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/design-tokens",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "description": "Auto Design Tokens",
   "type": "module",
   "license": "MIT",

--- a/packages/utility/file-caching/package.json
+++ b/packages/utility/file-caching/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/file-caching",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -45,9 +45,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.5.3",
-    "@autonomys/auto-dag-data": "^1.5.3",
-    "@autonomys/auto-utils": "^1.5.3",
+    "@autonomys/asynchronous": "^1.5.5",
+    "@autonomys/auto-dag-data": "^1.5.5",
+    "@autonomys/auto-utils": "^1.5.5",
     "@keyvhq/sqlite": "^2.1.7",
     "cache-manager": "^6.4.2",
     "jszip": "^3.10.1",

--- a/packages/utility/rpc/package.json
+++ b/packages/utility/rpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/rpc",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/autonomys/auto-sdk"

--- a/packages/utility/user-session/package.json
+++ b/packages/utility/user-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/user-session",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -31,9 +31,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.5.3",
-    "@autonomys/auto-dag-data": "^1.5.3",
-    "@autonomys/auto-drive": "^1.5.3",
+    "@autonomys/asynchronous": "^1.5.5",
+    "@autonomys/auto-dag-data": "^1.5.5",
+    "@autonomys/auto-drive": "^1.5.5",
     "ethers": "6.13.5"
   },
   "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@autonomys/asynchronous@npm:^1.5.3, @autonomys/asynchronous@workspace:packages/utility/asynchronous":
+"@autonomys/asynchronous@npm:^1.5.5, @autonomys/asynchronous@workspace:packages/utility/asynchronous":
   version: 0.0.0-use.local
   resolution: "@autonomys/asynchronous@workspace:packages/utility/asynchronous"
   dependencies:
@@ -45,12 +45,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-agents@npm:^1.5.3, @autonomys/auto-agents@workspace:packages/auto-agents":
+"@autonomys/auto-agents@npm:^1.5.5, @autonomys/auto-agents@workspace:packages/auto-agents":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-agents@workspace:packages/auto-agents"
   dependencies:
-    "@autonomys/auto-dag-data": "npm:^1.5.3"
-    "@autonomys/auto-drive": "npm:^1.5.3"
+    "@autonomys/auto-dag-data": "npm:^1.5.5"
+    "@autonomys/auto-drive": "npm:^1.5.5"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     ethers: "npm:6.13.5"
@@ -61,11 +61,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-consensus@npm:^1.5.3, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
+"@autonomys/auto-consensus@npm:^1.5.5, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-consensus@workspace:packages/auto-consensus"
   dependencies:
-    "@autonomys/auto-utils": "npm:^1.5.3"
+    "@autonomys/auto-utils": "npm:^1.5.5"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     jest: "npm:^29.7.0"
@@ -75,11 +75,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-dag-data@npm:^1.5.3, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
+"@autonomys/auto-dag-data@npm:^1.5.5, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-dag-data@workspace:packages/auto-dag-data"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.5.3"
+    "@autonomys/asynchronous": "npm:^1.5.5"
     "@ipld/dag-pb": "npm:^4.1.3"
     "@peculiar/webcrypto": "npm:^1.5.0"
     "@types/jest": "npm:^29.5.14"
@@ -103,7 +103,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-design-system@workspace:packages/auto-design-system"
   dependencies:
-    "@autonomys/design-tokens": "npm:^1.5.3"
+    "@autonomys/design-tokens": "npm:^1.5.5"
     "@babel/core": "npm:^7.27.1"
     "@babel/preset-env": "npm:^7.27.2"
     "@babel/preset-react": "npm:^7.27.1"
@@ -171,13 +171,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-drive@npm:^1.5.3, @autonomys/auto-drive@workspace:*, @autonomys/auto-drive@workspace:packages/auto-drive":
+"@autonomys/auto-drive@npm:^1.5.5, @autonomys/auto-drive@workspace:*, @autonomys/auto-drive@workspace:packages/auto-drive":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-drive@workspace:packages/auto-drive"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.5.3"
-    "@autonomys/auto-dag-data": "npm:^1.5.3"
-    "@autonomys/auto-utils": "npm:^1.5.3"
+    "@autonomys/asynchronous": "npm:^1.5.5"
+    "@autonomys/auto-dag-data": "npm:^1.5.5"
+    "@autonomys/auto-utils": "npm:^1.5.5"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"
     "@rollup/plugin-json": "npm:^6.1.0"
@@ -201,7 +201,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-files@workspace:packages/auto-files"
   dependencies:
-    "@autonomys/auto-drive": "npm:^1.5.3"
+    "@autonomys/auto-drive": "npm:^1.5.5"
     typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
@@ -210,8 +210,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-mcp-servers@workspace:packages/auto-mcp-servers"
   dependencies:
-    "@autonomys/auto-agents": "npm:^1.5.3"
-    "@autonomys/auto-drive": "npm:^1.5.3"
+    "@autonomys/auto-agents": "npm:^1.5.5"
+    "@autonomys/auto-drive": "npm:^1.5.5"
     "@modelcontextprotocol/sdk": "npm:^1.9.0"
     "@types/node": "npm:22.14.0"
     ts-node: "npm:^10.9.1"
@@ -245,7 +245,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-utils@npm:^1.5.3, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
+"@autonomys/auto-utils@npm:^1.5.5, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-utils@workspace:packages/auto-utils"
   dependencies:
@@ -267,8 +267,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-xdm@workspace:packages/auto-xdm"
   dependencies:
-    "@autonomys/auto-consensus": "npm:^1.5.3"
-    "@autonomys/auto-utils": "npm:^1.5.3"
+    "@autonomys/auto-consensus": "npm:^1.5.5"
+    "@autonomys/auto-utils": "npm:^1.5.5"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     jest: "npm:^29.7.0"
@@ -290,7 +290,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/design-tokens@npm:^1.5.3, @autonomys/design-tokens@workspace:packages/utility/design-tokens":
+"@autonomys/design-tokens@npm:^1.5.5, @autonomys/design-tokens@workspace:packages/utility/design-tokens":
   version: 0.0.0-use.local
   resolution: "@autonomys/design-tokens@workspace:packages/utility/design-tokens"
   dependencies:
@@ -313,9 +313,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/file-caching@workspace:packages/utility/file-caching"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.5.3"
-    "@autonomys/auto-dag-data": "npm:^1.5.3"
-    "@autonomys/auto-utils": "npm:^1.5.3"
+    "@autonomys/asynchronous": "npm:^1.5.5"
+    "@autonomys/auto-dag-data": "npm:^1.5.5"
+    "@autonomys/auto-utils": "npm:^1.5.5"
     "@keyvhq/sqlite": "npm:^2.1.7"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"
@@ -356,9 +356,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/user-session@workspace:packages/utility/user-session"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.5.3"
-    "@autonomys/auto-dag-data": "npm:^1.5.3"
-    "@autonomys/auto-drive": "npm:^1.5.3"
+    "@autonomys/asynchronous": "npm:^1.5.5"
+    "@autonomys/auto-dag-data": "npm:^1.5.5"
+    "@autonomys/auto-drive": "npm:^1.5.5"
     eslint: "npm:^9.25.1"
     ethers: "npm:6.13.5"
     prettier: "npm:^3.5.3"


### PR DESCRIPTION
This pull request includes updates to version `1.5.5` across multiple packages, along with new features and dependency updates. The most notable changes include the addition of new features documented in the changelog and the version bump for all packages and their dependencies.

### New Features
* Added `headDomainNumber` function to retrieve the latest block number for a specific domain.
* Introduced storage fee refunds for pending withdrawals.

### Version Updates
* Updated all package versions from `1.5.3` to `1.5.5` in `package.json`, `package-lock.json`, and `lerna.json`. [[1]](diffhunk://#diff-1796d8effff5f3271dfcf4c44ba3b8a7a5d5d4b213afe27eee2f72dddcc4fe50L3-R3) [[2]](diffhunk://#diff-d7decfac1c821bf150a00819017759e1d3d457c43411a2abb2ab50b3dbd35180L3-R9) [[3]](diffhunk://#diff-2d72bdead8afa0798d18995311992d684348a694c2d5e214e8e4d2b6153e4821L3-R3)

### Dependency Updates
* Updated internal dependencies to use version `^1.5.5` across all packages. For example:
  - `@autonomys/auto-dag-data` and `@autonomys/auto-drive` in `packages/auto-agents/package.json`.
  - `@autonomys/asynchronous` and `@autonomys/auto-utils` in `packages/auto-drive/package.json`.
  - `@autonomys/auto-consensus` and `@autonomys/auto-utils` in `packages/auto-xdm/package.json`.

### Documentation Updates
* Updated `CHANGELOG.md` to reflect the new version `1.5.5` and the added features.