### PR TITLE
Add mainnet Auto EVM domain and remove Gemini 3h from networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ import { balance } from '@autonomys/auto-consensus'
   // Activate a wallet using a mnemonic phrase
   const { api, accounts } = await activateWallet({
     mnemonic: 'your mnemonic phrase here', // Replace with your mnemonic
-    networkId: 'gemini-3h', // Optional: specify the network ID
+    networkId: 'mainnet', // Optional: specify the network ID
   })
 
   const account = accounts[0]

--- a/packages/auto-consensus/src/account.ts
+++ b/packages/auto-consensus/src/account.ts
@@ -6,27 +6,27 @@ import { parseBalance, parseBN } from './utils'
 
 /**
  * Retrieves detailed account information including nonce and balance data.
- * 
+ *
  * This function queries the system account storage to get comprehensive account information
  * including the account nonce (transaction counter) and balance details (free, reserved, frozen, flags).
- * 
+ *
  * @param api - The connected API instance to query the blockchain
  * @param address - The account address to query information for
  * @returns Promise that resolves to AccountData containing nonce and balance information
  * @throws Error if the account query fails or if there's an issue parsing the data
- * 
+ *
  * @example
  * ```typescript
  * import { account } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const accountData = await account(api, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY')
- * 
+ *
  * console.log(`Nonce: ${accountData.nonce}`)
  * console.log(`Free Balance: ${accountData.data.free}`)
  * console.log(`Reserved Balance: ${accountData.data.reserved}`)
- * 
+ *
  * await api.disconnect()
  * ```
  */

--- a/packages/auto-consensus/src/balances.ts
+++ b/packages/auto-consensus/src/balances.ts
@@ -52,7 +52,7 @@ export const totalIssuance = async (networkId?: string) => {
  * import { balance } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  * const balanceData = await balance(api, '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY')
  *
  * console.log(`Free Balance: ${balanceData.free}`)

--- a/packages/auto-consensus/src/batch.ts
+++ b/packages/auto-consensus/src/batch.ts
@@ -3,29 +3,29 @@ import type { ApiPromise } from '@autonomys/auto-utils'
 
 /**
  * Creates a batch transaction that executes multiple transactions atomically.
- * 
+ *
  * This function creates a utility batch transaction that allows multiple operations to be
  * executed together in a single transaction. All operations in the batch will either
  * succeed together or fail together, ensuring atomicity.
- * 
+ *
  * @param api - The connected API promise instance
  * @param txs - Array of transaction objects to be batched together
  * @returns A batch transaction that can be signed and submitted
- * 
+ *
  * @example
  * ```typescript
  * import { batch, transfer } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
- * 
+ *
+ * const api = await activate({ networkId: 'mainnet' })
+ *
  * // Create multiple transfer transactions
  * const tx1 = transfer(api, 'recipient1', '1000000000000')
  * const tx2 = transfer(api, 'recipient2', '2000000000000')
- * 
+ *
  * // Batch them together
  * const batchTx = batch(api, [tx1, tx2])
- * 
+ *
  * // Sign and send the batch transaction
  * await signAndSendTx(sender, batchTx)
  * ```

--- a/packages/auto-consensus/src/domain.ts
+++ b/packages/auto-consensus/src/domain.ts
@@ -20,7 +20,7 @@ import { parseDomain } from './utils/parse'
  * import { domains } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  * const domainList = await domains(api)
  *
  * domainList.forEach(domain => {
@@ -69,7 +69,7 @@ export async function domainStakingSummary(
  * import { domainStakingSummary } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * // Get all domain staking summaries
  * const allSummaries = await domainStakingSummary(api)
@@ -134,7 +134,7 @@ export async function domainStakingSummary(
  * import { latestConfirmedDomainBlock } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  * const confirmedBlocks = await latestConfirmedDomainBlock(api)
  *
  * confirmedBlocks.forEach(block => {
@@ -175,7 +175,7 @@ export const latestConfirmedDomainBlock = async (api: Api): Promise<ConfirmedDom
  * import { headDomainNumber } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  * const headNumber = await headDomainNumber(api, '0')
  *
  * if (headNumber !== undefined) {

--- a/packages/auto-consensus/src/info.ts
+++ b/packages/auto-consensus/src/info.ts
@@ -18,22 +18,22 @@ const PIECE_SIZE = BigInt(1048576)
 
 /**
  * Executes an RPC call on the blockchain API.
- * 
+ *
  * This is a generic function that allows calling any RPC method available on the blockchain API.
  * RPC calls are remote procedure calls that interact with the blockchain node.
- * 
+ *
  * @param api - The connected API instance
  * @param methodPath - The RPC method path (e.g., 'chain.getHeader', 'system.health')
  * @param params - Array of parameters to pass to the RPC method
  * @returns Promise that resolves to the RPC call result
  * @throws Error if the RPC call fails or method path is invalid
- * 
+ *
  * @example
  * ```typescript
  * import { rpc } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const header = await rpc(api, 'chain.getHeader', [])
  * const health = await rpc(api, 'system.health', [])
  * ```
@@ -43,22 +43,22 @@ export const rpc = async <T>(api: Api, methodPath: string, params: any[] = []): 
 
 /**
  * Executes a storage query on the blockchain API.
- * 
+ *
  * This is a generic function that allows querying any storage item available on the blockchain.
  * Storage queries retrieve data that is stored on-chain in the blockchain's state.
- * 
+ *
  * @param api - The connected API instance
  * @param methodPath - The storage query path (e.g., 'system.account', 'balances.totalIssuance')
  * @param params - Array of parameters to pass to the storage query
  * @returns Promise that resolves to the storage query result
  * @throws Error if the storage query fails or method path is invalid
- * 
+ *
  * @example
  * ```typescript
  * import { query } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const totalIssuance = await query(api, 'balances.totalIssuance', [])
  * const accountData = await query(api, 'system.account', ['5GrwvaEF5z...'])
  * ```
@@ -68,20 +68,20 @@ export const query = async <T>(api: Api, methodPath: string, params: any[] = [])
 
 /**
  * Retrieves the header information of the latest block.
- * 
+ *
  * The block header contains metadata about a block including its number, parent hash,
  * state root, and extrinsics root. This function gets the header of the current latest block.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to the block Header
  * @throws Error if the header query fails
- * 
+ *
  * @example
  * ```typescript
  * import { header } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const blockHeader = await header(api)
  * console.log(`Block number: ${blockHeader.number}`)
  * console.log(`Parent hash: ${blockHeader.parentHash}`)
@@ -91,25 +91,25 @@ export const header = async (api: Api) => await rpc<Header>(api, 'chain.getHeade
 
 /**
  * Retrieves a complete block including its extrinsics.
- * 
+ *
  * This function fetches a full block with all its transaction data (extrinsics).
  * If no block hash is provided, it returns the latest block.
- * 
+ *
  * @param api - The connected API instance
  * @param blockHash - Optional block hash to fetch a specific block
  * @returns Promise that resolves to a SignedBlock containing all block data
  * @throws Error if the block query fails
- * 
+ *
  * @example
  * ```typescript
  * import { block } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
- * 
+ *
+ * const api = await activate({ networkId: 'mainnet' })
+ *
  * // Get latest block
  * const latestBlock = await block(api)
- * 
+ *
  * // Get specific block by hash
  * const specificBlock = await block(api, '0x1234...')
  * ```
@@ -119,24 +119,24 @@ export const block = async (api: Api, blockHash?: string) =>
 
 /**
  * Retrieves and parses all extrinsics from a block.
- * 
+ *
  * Extrinsics are transactions or operations that modify the blockchain state.
  * This function fetches a block and extracts all extrinsics in a parsed format
  * for easier consumption.
- * 
+ *
  * @param api - The connected API instance
  * @param blockHash - Optional block hash to fetch extrinsics from a specific block
  * @returns Promise that resolves to an array of parsed Extrinsic objects
  * @throws Error if the block query or parsing fails
- * 
+ *
  * @example
  * ```typescript
  * import { blockExtrinsics } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const extrinsics = await blockExtrinsics(api)
- * 
+ *
  * extrinsics.forEach(ext => {
  *   console.log(`${ext.section}.${ext.method} by ${ext.signer}`)
  * })
@@ -147,24 +147,24 @@ export const blockExtrinsics = async (api: Api, blockHash?: string) =>
 
 /**
  * Retrieves and parses all transfer-related extrinsics from a block.
- * 
+ *
  * This function filters extrinsics to only include those related to token transfers,
  * such as balance transfers and cross-chain transfers. It's useful for tracking
  * token movement within a specific block.
- * 
+ *
  * @param api - The connected API instance
  * @param blockHash - Optional block hash to fetch transfers from a specific block
  * @returns Promise that resolves to an array of transfer Extrinsic objects
  * @throws Error if the block query or parsing fails
- * 
+ *
  * @example
  * ```typescript
  * import { blockTransfers } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const transfers = await blockTransfers(api)
- * 
+ *
  * console.log(`Found ${transfers.length} transfers in latest block`)
  * ```
  */
@@ -173,20 +173,20 @@ export const blockTransfers = async (api: Api, blockHash?: string) =>
 
 /**
  * Retrieves the current block number.
- * 
+ *
  * This function gets the block number of the latest block on the blockchain.
  * Block numbers increment sequentially as new blocks are produced.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to the current block number as a number
  * @throws Error if the block query fails
- * 
+ *
  * @example
  * ```typescript
  * import { blockNumber } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const currentBlock = await blockNumber(api)
  * console.log(`Current block: ${currentBlock}`)
  * ```
@@ -198,26 +198,26 @@ export const blockNumber = async (api: Api): Promise<number> => {
 
 /**
  * Retrieves the hash of a block.
- * 
+ *
  * This function gets the hash of a specific block by its number, or the latest
  * block hash if no block number is provided. Block hashes are unique identifiers
  * for each block.
- * 
+ *
  * @param api - The connected API instance
  * @param blockNumber - Optional block number to get hash for specific block
  * @returns Promise that resolves to the block hash as a hex string
  * @throws Error if the block hash query fails
- * 
+ *
  * @example
  * ```typescript
  * import { blockHash } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
- * 
+ *
+ * const api = await activate({ networkId: 'mainnet' })
+ *
  * // Get latest block hash
  * const latestHash = await blockHash(api)
- * 
+ *
  * // Get hash of specific block
  * const specificHash = await blockHash(api, 1000)
  * ```
@@ -229,20 +229,20 @@ export const blockHash = async (api: Api, blockNumber?: number) => {
 
 /**
  * Retrieves the hash of the finalized head block.
- * 
+ *
  * The finalized head is the latest block that has been finalized by the consensus
  * mechanism and is considered irreversible. This provides the hash of that block.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to the finalized head block hash
  * @throws Error if the finalized head query fails
- * 
+ *
  * @example
  * ```typescript
  * import { finalizedHead } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const finalizedHash = await finalizedHead(api)
  * console.log(`Finalized block hash: ${finalizedHash}`)
  * ```
@@ -252,21 +252,21 @@ export const finalizedHead = async (api: Api) =>
 
 /**
  * Retrieves the current network timestamp.
- * 
+ *
  * This function gets the timestamp of the current block, which represents
  * the time when the block was produced. The timestamp is set by block producers
  * and represents network time.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to the network timestamp as a Codec
  * @throws Error if the timestamp query fails
- * 
+ *
  * @example
  * ```typescript
  * import { networkTimestamp } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const timestamp = await networkTimestamp(api)
  * const networkTime = new Date(Number(timestamp.toString()))
  * console.log(`Network time: ${networkTime}`)
@@ -276,21 +276,21 @@ export const networkTimestamp = async (api: Api) => await query<Codec>(api, 'tim
 
 /**
  * Retrieves the current solution ranges for the consensus mechanism.
- * 
+ *
  * Solution ranges are used in the Proof of Archival Storage consensus to determine
  * the difficulty of finding valid solutions. This includes current and next solution
  * ranges for both regular consensus and voting.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to solution ranges object with current/next values
  * @throws Error if the solution ranges query fails
- * 
+ *
  * @example
  * ```typescript
  * import { solutionRanges } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const ranges = await solutionRanges(api)
  * console.log(`Current solution range: ${ranges.current}`)
  * console.log(`Next solution range: ${ranges.next}`)
@@ -314,20 +314,20 @@ export const solutionRanges = async (api: Api) => {
 
 /**
  * Checks if the solution range should be adjusted.
- * 
+ *
  * This function queries whether the consensus mechanism has determined that
  * the solution range needs to be adjusted based on network conditions.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to boolean indicating if adjustment is needed
  * @throws Error if the query fails
- * 
+ *
  * @example
  * ```typescript
  * import { shouldAdjustSolutionRange } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const shouldAdjust = await shouldAdjustSolutionRange(api)
  * console.log(`Solution range adjustment needed: ${shouldAdjust}`)
  * ```
@@ -337,21 +337,21 @@ export const shouldAdjustSolutionRange = async (api: Api): Promise<boolean> =>
 
 /**
  * Retrieves segment commitment information.
- * 
+ *
  * Segment commitments are cryptographic commitments to data segments in the
  * Autonomys network's decentralized storage system. This function retrieves
  * all current segment commitments.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to array of segment commitment entries
  * @throws Error if the segment commitment query fails
- * 
+ *
  * @example
  * ```typescript
  * import { segmentCommitment } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const commitments = await segmentCommitment(api)
  * console.log(`Found ${commitments.length} segment commitments`)
  * ```
@@ -366,19 +366,19 @@ export const segmentCommitment = async (api: Api) => {
 
 /**
  * Retrieves the slot probability configuration.
- * 
+ *
  * Slot probability defines the likelihood that a farmer will be able to produce
  * a block in any given slot. It's returned as a fraction [numerator, denominator].
- * 
+ *
  * @param api - The connected API instance
  * @returns Tuple representing slot probability as [numerator, denominator]
- * 
+ *
  * @example
  * ```typescript
  * import { slotProbability } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const [num, den] = slotProbability(api)
  * console.log(`Slot probability: ${num}/${den} = ${num/den}`)
  * ```
@@ -388,20 +388,20 @@ export const slotProbability = (api: Api): [number, number] =>
 
 /**
  * Retrieves the maximum number of pieces that can fit in a sector.
- * 
+ *
  * In the Autonomys storage system, data is organized into pieces and sectors.
  * This function returns the maximum number of pieces that can be stored in
  * a single sector.
- * 
+ *
  * @param api - The connected API instance
  * @returns Maximum pieces per sector as a bigint
- * 
+ *
  * @example
  * ```typescript
  * import { maxPiecesInSector } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const maxPieces = maxPiecesInSector(api)
  * console.log(`Max pieces per sector: ${maxPieces}`)
  * ```
@@ -411,24 +411,24 @@ export const maxPiecesInSector = (api: Api): bigint =>
 
 /**
  * Converts solution range to the equivalent number of pieces.
- * 
+ *
  * This utility function converts a solution range value to the equivalent
  * number of pieces that would need to be stored to achieve that solution range,
  * taking into account the slot probability.
- * 
+ *
  * @param solutionRange - The solution range value to convert
  * @param slotProbability - Slot probability as [numerator, denominator] tuple
  * @returns Number of pieces equivalent to the solution range
- * 
+ *
  * @example
  * ```typescript
  * import { solutionRangeToPieces, solutionRanges, slotProbability } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const ranges = await solutionRanges(api)
  * const slotProb = slotProbability(api)
- * 
+ *
  * if (ranges.current) {
  *   const pieces = solutionRangeToPieces(ranges.current, [BigInt(slotProb[0]), BigInt(slotProb[1])])
  *   console.log(`Current solution range equals ${pieces} pieces`)
@@ -452,21 +452,21 @@ export function solutionRangeToPieces(
 
 /**
  * Calculates the total space pledged to the network.
- * 
+ *
  * This function calculates the total amount of storage space that has been
  * pledged to the Autonomys network by farmers, based on the current solution
  * range and slot probability.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to total pledged space in bytes as bigint
  * @throws Error if unable to retrieve solution ranges or calculate space
- * 
+ *
  * @example
  * ```typescript
  * import { spacePledged } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const pledgedSpace = await spacePledged(api)
  * const pledgedGB = Number(pledgedSpace) / (1024 ** 3)
  * console.log(`Total pledged space: ${pledgedGB.toFixed(2)} GB`)
@@ -489,9 +489,9 @@ export const spacePledged = async (api: Api): Promise<bigint> => {
 
 /**
  * @deprecated Use spacePledged instead. This function will be removed in a future major release.
- * 
+ *
  * Calculates the total space pledged to the network.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to total pledged space in bytes as bigint
  */
@@ -505,21 +505,21 @@ export const spacePledge = async (api: Api): Promise<bigint> => {
 
 /**
  * Calculates the total blockchain size.
- * 
+ *
  * This function calculates the total size of the blockchain by counting
  * the number of segment commitments and multiplying by the size per segment.
  * This represents the total amount of data stored in the blockchain.
- * 
+ *
  * @param api - The connected API instance
  * @returns Promise that resolves to total blockchain size in bytes as bigint
  * @throws Error if unable to retrieve segment commitments
- * 
+ *
  * @example
  * ```typescript
  * import { blockchainSize } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
+ *
+ * const api = await activate({ networkId: 'mainnet' })
  * const totalSize = await blockchainSize(api)
  * const sizeGB = Number(totalSize) / (1024 ** 3)
  * console.log(`Blockchain size: ${sizeGB.toFixed(2)} GB`)

--- a/packages/auto-consensus/src/position/utils.ts
+++ b/packages/auto-consensus/src/position/utils.ts
@@ -16,7 +16,7 @@
  * import { shareToStake, instantSharePrice } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * // Get current share price
  * const sharePrice = await instantSharePrice(api, '1')
@@ -50,7 +50,7 @@ export const shareToStake = (shares: bigint, price: bigint): bigint => {
  * import { stakeToShare, instantSharePrice } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * // Get current share price
  * const sharePrice = await instantSharePrice(api, '1')

--- a/packages/auto-consensus/src/remark.ts
+++ b/packages/auto-consensus/src/remark.ts
@@ -2,29 +2,29 @@ import type { ApiPromise } from '@autonomys/auto-utils'
 
 /**
  * Creates a remark transaction for adding arbitrary data to the blockchain.
- * 
+ *
  * Remark transactions allow you to include arbitrary data in the blockchain without
  * affecting the state. This is useful for timestamping data, adding metadata,
  * or including custom information that needs to be permanently recorded.
- * 
+ *
  * @param api - The connected API promise instance
  * @param remark - The remark data to include in the transaction (as string or bytes)
  * @param withEvent - Whether to emit an event for this remark (default: false)
  * @returns A submittable remark transaction
- * 
+ *
  * @example
  * ```typescript
  * import { remark } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
- * 
+ *
+ * const api = await activate({ networkId: 'mainnet' })
+ *
  * // Create a simple remark
  * const remarkTx = remark(api, 'Hello, blockchain!')
- * 
+ *
  * // Create a remark with event
  * const remarkWithEventTx = remark(api, JSON.stringify({ timestamp: Date.now() }), true)
- * 
+ *
  * // Sign and send the transaction
  * await signAndSendTx(sender, remarkTx)
  * ```

--- a/packages/auto-consensus/src/staking.ts
+++ b/packages/auto-consensus/src/staking.ts
@@ -40,7 +40,7 @@ import {
  * import { operators } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  * const allOperators = await operators(api)
  *
  * allOperators.forEach(op => {
@@ -75,7 +75,7 @@ export const operators = async (api: Api) => {
  * import { operator } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  * const operatorInfo = await operator(api, '1')
  *
  * console.log(`Domain: ${operatorInfo.currentDomainId}`)
@@ -111,7 +111,7 @@ export const operator = async (api: Api, operatorId: StringNumberOrBigInt) => {
  * import { deposits } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * // Get all deposits for operator
  * const allDeposits = await deposits(api, '1')
@@ -163,7 +163,7 @@ export const deposits = async (
  * import { withdrawals } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * // Get all withdrawals for operator
  * const allWithdrawals = await withdrawals(api, '1')
@@ -223,8 +223,8 @@ export const withdrawals = async (
  * import { registerOperator } from '@autonomys/auto-consensus'
  * import { activate, activateWallet, signAndSendTx } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
- * const { accounts } = await activateWallet({ networkId: 'gemini-3h', mnemonic })
+ * const api = await activate({ networkId: 'mainnet' })
+ * const { accounts } = await activateWallet({ networkId: 'mainnet', mnemonic })
  *
  * const registerTx = registerOperator({
  *   api,
@@ -278,7 +278,7 @@ export const registerOperator = (params: RegisterOperatorParams) => {
  * import { nominateOperator } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * const nominateTx = nominateOperator({
  *   api,
@@ -322,7 +322,7 @@ export const nominateOperator = (params: NominateOperatorParams) => {
  * import { withdrawStake } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * // Withdraw all stake
  * const withdrawAllTx = withdrawStake({ api, operatorId: '1', all: true })
@@ -379,7 +379,7 @@ export const withdrawStake = (params: WithdrawStakeParams) => {
  * import { deregisterOperator } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * const deregisterTx = deregisterOperator({
  *   api,
@@ -418,7 +418,7 @@ export const deregisterOperator = (params: StakingParams) => {
  * import { unlockFunds } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * const unlockTx = unlockFunds({
  *   api,
@@ -458,7 +458,7 @@ export const unlockFunds = (params: StakingParams) => {
  * import { unlockNominator } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * const unlockNominatorTx = unlockNominator({
  *   api,

--- a/packages/auto-consensus/src/transfer.ts
+++ b/packages/auto-consensus/src/transfer.ts
@@ -22,7 +22,7 @@ export type Amount = bigint | number | string
  * import { transfer } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * // Transfer 1 AI3 (keeping account alive)
  * const keepAliveTx = transfer(api, 'recipient_address', '1000000000000000000')
@@ -63,7 +63,7 @@ export const transfer = (
  * import { transferAll } from '@autonomys/auto-consensus'
  * import { activate, signAndSendTx } from '@autonomys/auto-utils'
  *
- * const api = await activate({ networkId: 'gemini-3h' })
+ * const api = await activate({ networkId: 'mainnet' })
  *
  * // Transfer all tokens and close account
  * const transferAllTx = transferAll(api, 'recipient_address', false)

--- a/packages/auto-consensus/src/utils/query.ts
+++ b/packages/auto-consensus/src/utils/query.ts
@@ -3,31 +3,31 @@ import { Api } from '@autonomys/auto-utils'
 
 /**
  * Executes a method on the API by traversing the method path dynamically.
- * 
+ *
  * This utility function allows dynamic execution of API methods by parsing
  * a dot-separated method path and calling the corresponding function on the
  * API object. It's used internally by other functions to provide generic
  * access to RPC calls and storage queries.
- * 
+ *
  * @param api - The connected API instance
  * @param methodPath - Dot-separated path to the method (e.g., 'rpc.chain.getHeader', 'query.system.account')
  * @param params - Array of parameters to pass to the method
  * @returns Promise that resolves to the method call result
  * @throws Error if the method path is invalid or method execution fails
- * 
+ *
  * @example
  * ```typescript
  * import { queryMethodPath } from '@autonomys/auto-consensus'
  * import { activate } from '@autonomys/auto-utils'
- * 
- * const api = await activate({ networkId: 'gemini-3h' })
- * 
+ *
+ * const api = await activate({ networkId: 'mainnet' })
+ *
  * // Execute an RPC call
  * const header = await queryMethodPath(api, 'rpc.chain.getHeader', [])
- * 
+ *
  * // Execute a storage query
  * const totalIssuance = await queryMethodPath(api, 'query.balances.totalIssuance', [])
- * 
+ *
  * // Execute with parameters
  * const account = await queryMethodPath(api, 'query.system.account', ['address'])
  * ```

--- a/packages/auto-utils/README.md
+++ b/packages/auto-utils/README.md
@@ -70,7 +70,7 @@ import { activateWallet } from '@autonomys/auto-utils'
   // Activate the wallet
   const { api, accounts } = await activateWallet({
     mnemonic,
-    networkId: 'gemini-3h', // Optional: specify the network ID
+    networkId: 'mainnet', // Optional: specify the network ID
   })
 
   const account = accounts[0]
@@ -121,7 +121,7 @@ Create mock wallets for testing purposes:
 ```typescript
 import { activate, mockWallets, getMockWallet } from '@autonomys/auto-utils'
 ;(async () => {
-  const api = await activate({ networkId: 'gemini-3h' })
+  const api = await activate({ networkId: 'mainnet' })
 
   const wallets = await mockWallets({}, api)
   const aliceWallet = getMockWallet('Alice', wallets)
@@ -158,7 +158,7 @@ Retrieve details of a specific network:
 ```typescript
 import { getNetworkDetails } from '@autonomys/auto-utils'
 
-const network = getNetworkDetails({ networkId: 'gemini-3h' })
+const network = getNetworkDetails({ networkId: 'mainnet' })
 console.log(`Network Name: ${network.name}`)
 console.log(`RPC URLs: ${network.rpcUrls.join(', ')}`)
 ```
@@ -170,7 +170,7 @@ Retrieve details of a specific domain within a network:
 ```typescript
 import { getNetworkDomainDetails } from '@autonomys/auto-utils'
 
-const domain = getNetworkDomainDetails({ domainId: '1', networkId: 'gemini-3h' })
+const domain = getNetworkDomainDetails({ domainId: '0', networkId: 'mainnet' })
 console.log(`Domain Name: ${domain.name}`)
 console.log(`RPC URLs: ${domain.rpcUrls.join(', ')}`)
 ```
@@ -232,7 +232,7 @@ Connect to the Autonomys Network:
 ```typescript
 import { activate } from '@autonomys/auto-utils'
 ;(async () => {
-  const api = await activate({ networkId: 'gemini-3h' })
+  const api = await activate({ networkId: 'mainnet' })
 
   console.log('API connected')
 
@@ -250,7 +250,7 @@ Connect to a specific domain within the network:
 ```typescript
 import { activateDomain } from '@autonomys/auto-utils'
 ;(async () => {
-  const api = await activateDomain({ domainId: '1', networkId: 'gemini-3h' })
+  const api = await activateDomain({ domainId: '0', networkId: 'mainnet' })
 
   console.log('Domain API connected')
 

--- a/packages/auto-utils/src/api.ts
+++ b/packages/auto-utils/src/api.ts
@@ -10,29 +10,29 @@ import {
 
 /**
  * Creates a connection to a Polkadot.js API instance with WebSocket provider.
- * 
+ *
  * This function establishes a WebSocket connection to the Autonomys Network or domain
  * and returns a fully initialized ApiPromise instance. It automatically includes
  * the necessary chain types and waits for the API to be ready before returning.
- * 
+ *
  * @param endpoint - The WebSocket endpoint URL(s) to connect to. Can be a single URL or array of URLs.
  * @param options - Optional configuration for the API instance.
  * @returns A Promise that resolves to an initialized ApiPromise instance.
- * 
+ *
  * @example
  * import { createConnection } from '@autonomys/auto-utils'
- * 
+ *
  * // Connect to single endpoint
  * const api = await createConnection('wss://rpc-0.taurus.autonomys.xyz/ws')
  * console.log('Connected to API')
- * 
+ *
  * // Connect with multiple endpoints for failover
  * const endpoints = [
  *   'wss://rpc-0.taurus.autonomys.xyz/ws',
  *   'wss://rpc-1.taurus.autonomys.xyz/ws'
  * ]
  * const apiWithFailover = await createConnection(endpoints)
- * 
+ *
  * // Connect with custom options
  * const customApi = await createConnection(
  *   'wss://rpc-0.taurus.autonomys.xyz/ws',
@@ -41,10 +41,10 @@ import {
  *     types: { CustomType: 'u32' }
  *   }
  * )
- * 
+ *
  * // Always disconnect when done
  * await api.disconnect()
- * 
+ *
  * @throws {Error} When connection fails or API initialization fails.
  */
 export const createConnection = async (
@@ -67,39 +67,39 @@ export const createConnection = async (
 
 /**
  * Activates a connection to the Autonomys Network consensus layer.
- * 
+ *
  * This function simplifies connecting to the Autonomys Network by automatically
  * resolving the network RPC URLs and establishing a connection. It supports all
  * available networks including mainnet, testnet, and local development networks.
- * 
+ *
  * @param params - Optional network activation parameters including networkId and API options.
  * @returns A Promise that resolves to an initialized ApiPromise instance for the consensus layer.
- * 
+ *
  * @example
  * import { activate } from '@autonomys/auto-utils'
- * 
+ *
  * // Connect to default network (mainnet)
  * const api = await activate()
  * console.log('Connected to mainnet')
- * 
+ *
  * // Connect to specific network
  * const taurusApi = await activate({ networkId: 'taurus' })
  * console.log('Connected to Taurus testnet')
- * 
+ *
  * // Connect to local development network
  * const localApi = await activate({ networkId: 'localhost' })
  * console.log('Connected to localhost')
- * 
+ *
  * // Connect with custom API options
  * const customApi = await activate({
- *   networkId: 'gemini-3h',
+ *   networkId: 'mainnet',
  *   noInitWarn: false,
  *   types: { CustomType: 'u64' }
  * })
- * 
+ *
  * // Always disconnect when done
  * await api.disconnect()
- * 
+ *
  * @throws {Error} When the specified network is not found or connection fails.
  */
 export const activate = async (params?: ActivateParams<NetworkParams>): Promise<ApiPromise> => {
@@ -113,47 +113,47 @@ export const activate = async (params?: ActivateParams<NetworkParams>): Promise<
 
 /**
  * Activates a connection to a specific domain within the Autonomys Network.
- * 
+ *
  * This function connects to domain-specific networks like Auto-EVM or Auto-ID
  * which run as domains on top of the Autonomys consensus layer. Each domain
  * has its own RPC endpoints and may have domain-specific functionality.
- * 
+ *
  * @param params - Domain activation parameters including networkId, domainId, and API options.
  * @returns A Promise that resolves to an initialized ApiPromise instance for the specified domain.
- * 
+ *
  * @example
  * import { activateDomain } from '@autonomys/auto-utils'
- * 
- * // Connect to Auto-EVM domain on Taurus testnet
+ *
+ * // Connect to Auto-EVM domain on Mainnet testnet
  * const evmApi = await activateDomain({
- *   networkId: 'taurus',
+ *   networkId: 'mainnet',
  *   domainId: '0'
  * })
  * console.log('Connected to Auto-EVM domain')
- * 
- * // Connect to Auto-ID domain on Gemini-3H
- * const autoIdApi = await activateDomain({
- *   networkId: 'gemini-3h',
- *   domainId: '1'
+ *
+ * // Connect to Auto-EVM domain on Mainnet
+ * const autoEvmApi = await activateDomain({
+ *   networkId: 'mainnet',
+ *   domainId: '0'
  * })
- * console.log('Connected to Auto-ID domain')
- * 
+ * console.log('Connected to Auto-EVM domain')
+ *
  * // Connect to localhost domain for development
  * const localDomainApi = await activateDomain({
  *   networkId: 'localhost',
  *   domainId: '0'
  * })
- * 
+ *
  * // Connect with custom API options
  * const customDomainApi = await activateDomain({
- *   networkId: 'taurus',
+ *   networkId: 'mainnet',
  *   domainId: '0',
  *   noInitWarn: false
  * })
- * 
+ *
  * // Always disconnect when done
  * await evmApi.disconnect()
- * 
+ *
  * @throws {Error} When the specified network or domain is not found, or connection fails.
  */
 export const activateDomain = async (params: ActivateParams<DomainParams>): Promise<ApiPromise> => {
@@ -168,28 +168,28 @@ export const activateDomain = async (params: ActivateParams<DomainParams>): Prom
 
 /**
  * Disconnects an active API connection and cleans up resources.
- * 
+ *
  * This function properly closes the WebSocket connection and cleans up any
  * resources associated with the API instance. It should always be called
  * when you're done using an API connection to prevent resource leaks.
- * 
+ *
  * @param api - The ApiPromise instance to disconnect.
  * @returns A Promise that resolves when the disconnection is complete.
- * 
+ *
  * @example
  * import { activate, disconnect } from '@autonomys/auto-utils'
- * 
+ *
  * // Connect and then disconnect
  * const api = await activate({ networkId: 'taurus' })
- * 
+ *
  * // Use the API for operations...
  * const chainInfo = await api.rpc.system.chain()
  * console.log('Chain:', chainInfo.toString())
- * 
+ *
  * // Always disconnect when done
  * await disconnect(api)
  * console.log('API disconnected')
- * 
+ *
  * // Or use the API instance method directly
  * // await api.disconnect()
  */

--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -49,7 +49,13 @@ export const networks: Network[] = [
         url: SUBSCAN_EXPLORER,
       },
     ],
-    domains: [],
+    domains: [
+      {
+        domainId: '0',
+        ...domains[DomainRuntime.AUTO_EVM],
+        rpcUrls: ['wss://auto-evm.mainnet.autonomys.xyz/ws'],
+      },
+    ],
     token: DEFAULT_TOKEN,
   },
   {

--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -7,7 +7,6 @@ import { DEFAULT_TOKEN, TESTNET_TOKEN } from './token'
 export enum NetworkId {
   MAINNET = 'mainnet',
   TAURUS = 'taurus',
-  GEMINI_3H = 'gemini-3h',
   DEVNET = 'devnet',
   LOCALHOST = 'localhost',
 }
@@ -15,7 +14,6 @@ export enum NetworkId {
 export enum NetworkName {
   MAINNET = 'Mainnet',
   TAURUS = 'Testnet - Taurus',
-  GEMINI_3H = 'Testnet - Gemini 3H',
   DEVNET = 'Devnet',
   LOCALHOST = 'Localhost',
 }
@@ -85,31 +83,6 @@ export const networks: Network[] = [
           'wss://auto-evm-0.taurus.subspace.network/ws',
           'wss://auto-evm-1.taurus.subspace.network/ws',
         ],
-      },
-    ],
-    token: TESTNET_TOKEN,
-    isTestnet: true,
-  },
-  {
-    id: NetworkId.GEMINI_3H,
-    name: NetworkName.GEMINI_3H,
-    rpcUrls: ['wss://rpc-0.gemini-3h.subspace.network/ws'],
-    explorer: [
-      {
-        name: NetworkExplorerName.ASTRAL,
-        url: ASTRAL_EXPLORER + 'gemini-3h/consensus/',
-      },
-    ],
-    domains: [
-      {
-        domainId: '0',
-        ...domains[DomainRuntime.AUTO_EVM],
-        rpcUrls: ['wss://nova-0.gemini-3h.subspace.network/ws'],
-      },
-      {
-        domainId: '1',
-        ...domains[DomainRuntime.AUTO_ID],
-        rpcUrls: ['wss://autoid-0.gemini-3h.subspace.network/ws'],
       },
     ],
     token: TESTNET_TOKEN,

--- a/packages/auto-utils/src/constants/wallet.ts
+++ b/packages/auto-utils/src/constants/wallet.ts
@@ -14,6 +14,5 @@ export const mockURIs = [
 ]
 
 export const MAINNET_SS58_FORMAT = 6094
-export const GEMINI_3H_SS58_FORMAT = 2254
 
 export const DEFAULT_SS58_FORMAT = MAINNET_SS58_FORMAT

--- a/packages/auto-utils/src/network.ts
+++ b/packages/auto-utils/src/network.ts
@@ -5,37 +5,37 @@ import type { DomainParams, NetworkParams } from './types/network'
 
 /**
  * Retrieves detailed information about a specific Autonomys network.
- * 
+ *
  * This function provides access to comprehensive network configuration including
  * RPC endpoints, explorer URLs, domain information, and token details. If no
  * network ID is specified, it returns the default network (mainnet).
- * 
+ *
  * @param input - Optional network parameters containing the networkId.
  * @returns Complete network configuration object with all network details.
- * 
+ *
  * @example
  * import { getNetworkDetails } from '@autonomys/auto-utils'
- * 
+ *
  * // Get default network (mainnet)
  * const mainnet = getNetworkDetails()
  * console.log(mainnet.name) // Output: "Mainnet"
  * console.log(mainnet.token.symbol) // Output: "AI3"
- * 
+ *
  * // Get specific network details
- * const taurus = getNetworkDetails({ networkId: 'taurus' })
- * console.log(taurus.name) // Output: "Testnet - Taurus"
- * console.log(taurus.isTestnet) // Output: true
- * console.log(taurus.domains.length) // Output: 1 (Auto-EVM domain)
- * 
+ * const mainnet = getNetworkDetails({ networkId: 'mainnet' })
+ * console.log(mainnet.name) // Output: "Mainnet"
+ * console.log(mainnet.isTestnet) // Output: undefined
+ * console.log(mainnet.domains.length) // Output: 1 (Auto-EVM domain)
+ *
  * // Access network explorers
- * const gemini = getNetworkDetails({ networkId: 'gemini-3h' })
- * console.log(gemini.explorer[0].name) // Output: "Astral"
- * console.log(gemini.explorer[0].url) // Output: explorer URL
- * 
+ * const mainnet = getNetworkDetails({ networkId: 'mainnet' })
+ * console.log(mainnet.explorer[0].name) // Output: "Astral"
+ * console.log(mainnet.explorer[0].url) // Output: explorer URL
+ *
  * // Check if network is for local development
  * const localhost = getNetworkDetails({ networkId: 'localhost' })
  * console.log(localhost.isLocalhost) // Output: true
- * 
+ *
  * @throws {Error} When the specified networkId is not found in the available networks.
  */
 export const getNetworkDetails = (input?: NetworkParams) => {
@@ -53,36 +53,36 @@ export const getNetworkDetails = (input?: NetworkParams) => {
 
 /**
  * Retrieves the RPC endpoint URLs for a specific Autonomys network.
- * 
+ *
  * This function returns an array of WebSocket RPC URLs that can be used to
  * connect to the specified network's consensus layer. Multiple URLs provide
  * redundancy and load balancing capabilities.
- * 
+ *
  * @param input - Optional network parameters containing the networkId.
  * @returns Array of WebSocket RPC URLs for the specified network.
- * 
+ *
  * @example
  * import { getNetworkRpcUrls } from '@autonomys/auto-utils'
- * 
+ *
  * // Get mainnet RPC URLs
  * const mainnetUrls = getNetworkRpcUrls()
  * console.log(mainnetUrls)
  * // Output: ['wss://rpc-0.mainnet.subspace.network/ws', 'wss://rpc-1.mainnet.subspace.network/ws', ...]
- * 
+ *
  * // Get testnet RPC URLs
  * const taurusUrls = getNetworkRpcUrls({ networkId: 'taurus' })
  * console.log(taurusUrls)
  * // Output: ['wss://rpc-0.taurus.autonomys.xyz/ws', 'wss://rpc-1.taurus.autonomys.xyz/ws', ...]
- * 
+ *
  * // Use with API connection
  * import { createConnection } from '@autonomys/auto-utils'
- * const endpoints = getNetworkRpcUrls({ networkId: 'gemini-3h' })
+ * const endpoints = getNetworkRpcUrls({ networkId: 'mainnet' })
  * const api = await createConnection(endpoints)
- * 
+ *
  * // Get localhost URLs for development
  * const localUrls = getNetworkRpcUrls({ networkId: 'localhost' })
  * console.log(localUrls) // Output: ['ws://127.0.0.1:9944/ws']
- * 
+ *
  * @throws {Error} When the specified network is not found.
  * @throws {Error} When the network has no configured RPC URLs.
  */
@@ -97,17 +97,17 @@ export const getNetworkRpcUrls = (input?: NetworkParams) => {
 
 /**
  * Retrieves detailed information about a specific domain within an Autonomys network.
- * 
+ *
  * This function provides access to domain-specific configuration including
  * the domain's runtime type, name, and RPC endpoints. Domains are specialized
  * execution environments that run on top of the Autonomys consensus layer.
- * 
+ *
  * @param params - Domain parameters containing both networkId and domainId.
  * @returns Complete domain configuration object with runtime and connection details.
- * 
+ *
  * @example
  * import { getNetworkDomainDetails } from '@autonomys/auto-utils'
- * 
+ *
  * // Get Auto-EVM domain details on Taurus
  * const evmDomain = getNetworkDomainDetails({
  *   networkId: 'taurus',
@@ -116,22 +116,22 @@ export const getNetworkRpcUrls = (input?: NetworkParams) => {
  * console.log(evmDomain.name) // Output: "Auto-EVM"
  * console.log(evmDomain.runtime) // Output: "auto-evm"
  * console.log(evmDomain.rpcUrls.length) // Output: number of available RPC endpoints
- * 
- * // Get Auto-ID domain details on Gemini-3H
- * const autoIdDomain = getNetworkDomainDetails({
- *   networkId: 'gemini-3h',
- *   domainId: '1'
+ *
+ * // Get Auto-EVM domain details on Mainnet
+ * const autoEvmDomain = getNetworkDomainDetails({
+ *   networkId: 'mainnet',
+ *   domainId: '0'
  * })
- * console.log(autoIdDomain.name) // Output: "Auto-ID"
- * console.log(autoIdDomain.runtime) // Output: "auto-id"
- * 
+ * console.log(autoEvmDomain.name) // Output: "Auto-EVM"
+ * console.log(autoEvmDomain.runtime) // Output: "auto-evm"
+ *
  * // Use with domain connection
  * import { activateDomain } from '@autonomys/auto-utils'
  * const domainApi = await activateDomain({
  *   networkId: 'taurus',
  *   domainId: '0'
  * })
- * 
+ *
  * @throws {Error} When the specified networkId is not found.
  * @throws {Error} When the specified domainId is not found within the network.
  */
@@ -151,17 +151,17 @@ export const getNetworkDomainDetails = (params: DomainParams) => {
 
 /**
  * Retrieves the RPC endpoint URLs for a specific domain within an Autonomys network.
- * 
+ *
  * This function returns an array of WebSocket RPC URLs that can be used to
  * connect to the specified domain. Domain RPC endpoints provide access to
  * domain-specific functionality and state.
- * 
+ *
  * @param params - Domain parameters containing both networkId and domainId.
  * @returns Array of WebSocket RPC URLs for the specified domain.
- * 
+ *
  * @example
  * import { getNetworkDomainRpcUrls } from '@autonomys/auto-utils'
- * 
+ *
  * // Get Auto-EVM domain RPC URLs on Taurus
  * const evmUrls = getNetworkDomainRpcUrls({
  *   networkId: 'taurus',
@@ -169,15 +169,15 @@ export const getNetworkDomainDetails = (params: DomainParams) => {
  * })
  * console.log(evmUrls)
  * // Output: ['wss://auto-evm.taurus.autonomys.xyz/ws', 'wss://auto-evm-0.taurus.autonomys.xyz/ws', ...]
- * 
- * // Get Auto-ID domain RPC URLs on Gemini-3H
- * const autoIdUrls = getNetworkDomainRpcUrls({
- *   networkId: 'gemini-3h',
- *   domainId: '1'
+ *
+ * // Get Auto-EVM domain RPC URLs on Mainnet
+ * const autoEvmUrls = getNetworkDomainRpcUrls({
+ *   networkId: 'mainnet',
+ *   domainId: '0'
  * })
- * console.log(autoIdUrls)
- * // Output: ['wss://autoid-0.gemini-3h.subspace.network/ws']
- * 
+ * console.log(autoEvmUrls)
+ * // Output: ['wss://auto-evm.taurus.autonomys.xyz/ws']
+ *
  * // Use with API connection
  * import { createConnection } from '@autonomys/auto-utils'
  * const domainEndpoints = getNetworkDomainRpcUrls({
@@ -185,7 +185,7 @@ export const getNetworkDomainDetails = (params: DomainParams) => {
  *   domainId: '0'
  * })
  * const domainApi = await createConnection(domainEndpoints)
- * 
+ *
  * @throws {Error} When the specified network or domain is not found.
  * @throws {Error} When the domain has no configured RPC URLs.
  */

--- a/packages/auto-utils/src/string.ts
+++ b/packages/auto-utils/src/string.ts
@@ -2,28 +2,28 @@
 
 /**
  * Converts any value to a JSON string with BigInt support.
- * 
+ *
  * This function extends JSON.stringify to handle BigInt values by converting them to strings.
  * It's particularly useful when working with blockchain data that often includes large numbers
  * represented as BigInt values.
- * 
+ *
  * @param value - Any value to be stringified, including objects with BigInt properties.
  * @returns A JSON string representation of the value with BigInt values converted to strings.
- * 
+ *
  * @example
  * import { stringify } from '@autonomys/auto-utils'
- * 
+ *
  * // Stringify object with BigInt values
  * const data = {
  *   balance: BigInt('1000000000000000000'),
  *   timestamp: Date.now(),
  *   address: '5GmS1wtCfR4tK5SSgnZbVT4kYw5W8NmxmijcsxCQE6oLW6A8'
  * }
- * 
+ *
  * const jsonString = stringify(data)
  * console.log(jsonString)
  * // Output: {"balance":"1000000000000000000","timestamp":1672531200000,"address":"5G..."}
- * 
+ *
  * // Compare with regular JSON.stringify which would throw an error
  * // JSON.stringify(data) // TypeError: Do not know how to serialize a BigInt
  */
@@ -33,27 +33,27 @@ export const stringify = (value: any) =>
 
 /**
  * Truncates a string by keeping the beginning and end characters with ellipsis in the middle.
- * 
+ *
  * This function is commonly used to display long addresses, transaction hashes, or other
  * identifiers in a compact format while preserving recognizable parts of the original string.
- * 
+ *
  * @param value - The string to truncate.
  * @param initialLength - Number of characters to keep from the beginning. Defaults to 6.
  * @param endLength - Number of characters to keep from the end (negative number). Defaults to -4.
  * @returns The truncated string with ellipsis in the middle.
- * 
+ *
  * @example
  * import { shortString } from '@autonomys/auto-utils'
- * 
+ *
  * // Truncate a long address
  * const address = '5GmS1wtCfR4tK5SSgnZbVT4kYw5W8NmxmijcsxCQE6oLW6A8'
  * const short = shortString(address)
  * console.log(short) // Output: "5GmS1w...W6A8"
- * 
+ *
  * // Custom truncation lengths
  * const customShort = shortString(address, 8, -6)
  * console.log(customShort) // Output: "5GmS1wtC...oLW6A8"
- * 
+ *
  * // Truncate transaction hash
  * const txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
  * const shortHash = shortString(txHash, 10, -8)
@@ -64,20 +64,20 @@ export const shortString = (value: string, initialLength = 6, endLength = -4): s
 
 /**
  * Capitalizes the first letter of a string.
- * 
+ *
  * This utility function converts the first character of a string to uppercase while
  * leaving the rest of the string unchanged. It handles empty strings gracefully.
- * 
+ *
  * @param string - The string to capitalize.
  * @returns The string with the first letter capitalized, or empty string if input is empty.
- * 
+ *
  * @example
  * import { capitalizeFirstLetter } from '@autonomys/auto-utils'
- * 
+ *
  * // Capitalize network names
  * console.log(capitalizeFirstLetter('mainnet')) // Output: "Mainnet"
- * console.log(capitalizeFirstLetter('gemini-3h')) // Output: "Gemini-3h"
- * 
+ * console.log(capitalizeFirstLetter('taurus')) // Output: "Taurus"
+ *
  * // Handle edge cases
  * console.log(capitalizeFirstLetter('')) // Output: ""
  * console.log(capitalizeFirstLetter('a')) // Output: "A"
@@ -88,30 +88,30 @@ export const capitalizeFirstLetter = (string: string) =>
 
 /**
  * Creates a fixed-length entry identifier for blockchain events or transactions.
- * 
+ *
  * This function generates a standardized identifier format used for indexing blockchain
  * entries, combining block height with optional transaction index. Both values are
  * zero-padded to ensure consistent string length for sorting and indexing.
- * 
+ *
  * @param blockHeight - The block height as a BigInt.
  * @param indexInBlock - Optional transaction index within the block as a BigInt.
  * @returns A zero-padded string identifier, either "blockHeight" or "blockHeight-indexInBlock".
- * 
+ *
  * @example
  * import { fixLengthEntryId } from '@autonomys/auto-utils'
- * 
+ *
  * // Create block identifier
  * const blockId = fixLengthEntryId(BigInt(12345))
  * console.log(blockId) // Output: "00000000000000000000000000012345"
- * 
+ *
  * // Create transaction identifier
  * const txId = fixLengthEntryId(BigInt(12345), BigInt(7))
  * console.log(txId) // Output: "00000000000000000000000000012345-00000000000000000000000000000007"
- * 
+ *
  * // Use with large numbers
  * const largeBlockId = fixLengthEntryId(BigInt('1000000000000000000'))
  * console.log(largeBlockId) // Output: "00000000000001000000000000000000"
- * 
+ *
  * // Useful for creating sortable identifiers
  * const ids = [
  *   fixLengthEntryId(BigInt(100)),

--- a/packages/auto-utils/src/wallet.ts
+++ b/packages/auto-utils/src/wallet.ts
@@ -21,40 +21,40 @@ import type {
 
 /**
  * Sets up a wallet from a mnemonic phrase or derivation URI.
- * 
+ *
  * This function creates a KeyringPair from either a mnemonic phrase or a derivation
  * URI (like //Alice for development). It supports different key types including
  * sr25519 (default) and ethereum for cross-chain compatibility.
- * 
+ *
  * @param params - Wallet setup parameters containing either mnemonic or URI, plus optional key type.
  * @returns A Wallet object containing the KeyringPair and standardized addresses.
- * 
+ *
  * @example
  * import { setupWallet } from '@autonomys/auto-utils'
- * 
+ *
  * // Setup wallet from mnemonic (sr25519 default)
  * const wallet = setupWallet({
  *   mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
  * })
  * console.log(wallet.address) // Standardized Autonomys address
  * console.log(wallet.commonAddress) // Original address format
- * 
+ *
  * // Setup wallet with ethereum key type
  * const ethWallet = setupWallet({
  *   mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
  *   type: 'ethereum'
  * })
  * console.log(ethWallet.address) // Ethereum-format address (0x...)
- * 
+ *
  * // Setup development wallet from URI
  * const aliceWallet = setupWallet({ uri: '//Alice' })
  * console.log(aliceWallet.address) // Alice's development address
- * 
+ *
  * // Setup with custom derivation path
  * const customWallet = setupWallet({
  *   uri: '//Alice/stash'
  * })
- * 
+ *
  * @throws {Error} When neither mnemonic nor URI is provided, or when the input is invalid.
  */
 export const setupWallet = (params: SetupWalletParams): Wallet => {
@@ -79,28 +79,28 @@ export const setupWallet = (params: SetupWalletParams): Wallet => {
 
 /**
  * Generates a new wallet with a random mnemonic phrase.
- * 
+ *
  * This function creates a brand new wallet by generating a cryptographically secure
  * mnemonic phrase and deriving the corresponding KeyringPair. It's useful for creating
  * new user accounts or generating test wallets.
- * 
+ *
  * @param type - The cryptographic key type to use. Defaults to 'sr25519'.
  * @returns A GeneratedWallet object containing the mnemonic, KeyringPair, and addresses.
- * 
+ *
  * @example
  * import { generateWallet } from '@autonomys/auto-utils'
- * 
+ *
  * // Generate new sr25519 wallet (default)
  * const newWallet = generateWallet()
  * console.log(newWallet.mnemonic) // 12-word mnemonic phrase
  * console.log(newWallet.address) // Standardized Autonomys address
  * console.log(newWallet.commonAddress) // Original address format
- * 
+ *
  * // Generate ethereum-compatible wallet
  * const ethWallet = generateWallet('ethereum')
  * console.log(ethWallet.mnemonic) // Same 12-word mnemonic
  * console.log(ethWallet.address) // Ethereum-format address (0x...)
- * 
+ *
  * // Store the mnemonic securely for later use
  * const mnemonic = newWallet.mnemonic
  * // Use setupWallet later to recreate the same wallet
@@ -121,55 +121,55 @@ export const generateWallet = (type: KeypairType = 'sr25519'): GeneratedWallet =
 
 /**
  * Activates a wallet and establishes connection to the Autonomys Network or domain.
- * 
+ *
  * This comprehensive function handles wallet activation in both Node.js and browser
  * environments. It can work with mnemonic phrases, URIs, or browser extensions,
  * and automatically establishes the appropriate API connection.
- * 
+ *
  * @param params - Wallet activation parameters including credentials, network, and options.
  * @returns A WalletActivated object containing the API connection and account information.
- * 
+ *
  * @example
  * import { activateWallet } from '@autonomys/auto-utils'
- * 
+ *
  * // Activate wallet with mnemonic on mainnet
  * const { api, accounts } = await activateWallet({
  *   mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
  * })
  * console.log('Connected to mainnet')
  * console.log('Account address:', accounts[0].address)
- * 
+ *
  * // Activate on specific network
  * const { api: taurusApi, accounts: taurusAccounts } = await activateWallet({
  *   mnemonic: 'your mnemonic here',
  *   networkId: 'taurus'
  * })
- * 
+ *
  * // Activate on domain
  * const { api: domainApi, accounts: domainAccounts } = await activateWallet({
  *   uri: '//Alice',
  *   networkId: 'taurus',
  *   domainId: '0' // Auto-EVM domain
  * })
- * 
+ *
  * // Activate with ethereum key type
  * const { api: ethApi, accounts: ethAccounts } = await activateWallet({
  *   mnemonic: 'your mnemonic here',
  *   networkId: 'taurus',
  *   type: 'ethereum'
  * })
- * 
+ *
  * // Use with existing API instance
  * import { activate } from '@autonomys/auto-utils'
- * const existingApi = await activate({ networkId: 'gemini-3h' })
+ * const existingApi = await activate({ networkId: 'mainnet' })
  * const { accounts } = await activateWallet({
  *   uri: '//Bob',
  *   api: existingApi
  * })
- * 
+ *
  * // Always disconnect when done
  * await api.disconnect()
- * 
+ *
  * @throws {Error} When no wallet credentials are provided or connection fails.
  */
 export const activateWallet = async (params: ActivateWalletParams): Promise<WalletActivated> => {
@@ -211,45 +211,45 @@ export const activateWallet = async (params: ActivateWalletParams): Promise<Wall
 
 /**
  * Creates a collection of mock wallets for testing and development purposes.
- * 
+ *
  * This function generates wallets for all predefined development accounts
  * (Alice, Bob, Charlie, Dave, etc.) and establishes connections to the specified
  * network. It's essential for testing applications and running development scenarios.
- * 
+ *
  * @param network - Network parameters specifying which network to connect to. Defaults to mainnet.
  * @param api - Optional existing API instance to reuse. If not provided, creates new connections.
  * @param type - The cryptographic key type to use for all mock wallets. Defaults to 'sr25519'.
  * @returns Promise resolving to an array of WalletActivated objects for all mock accounts.
- * 
+ *
  * @example
  * import { mockWallets, activate } from '@autonomys/auto-utils'
- * 
+ *
  * // Create mock wallets for mainnet
  * const wallets = await mockWallets()
  * console.log('Created', wallets.length, 'mock wallets')
- * 
+ *
  * // Create mock wallets for testnet
  * const testWallets = await mockWallets({ networkId: 'taurus' })
- * 
+ *
  * // Create mock wallets with existing API
  * const api = await activate({ networkId: 'localhost' })
  * const localWallets = await mockWallets({ networkId: 'localhost' }, api)
- * 
+ *
  * // Create ethereum-type mock wallets
  * const ethWallets = await mockWallets(
  *   { networkId: 'taurus' },
  *   undefined,
  *   'ethereum'
  * )
- * 
+ *
  * // Use specific mock wallet
  * const aliceWallet = wallets[0] // Alice is always first
  * const bobWallet = wallets[1]   // Bob is always second
- * 
+ *
  * // Access wallet details
  * console.log('Alice address:', aliceWallet.accounts[0].address)
  * console.log('Bob address:', bobWallet.accounts[0].address)
- * 
+ *
  * // Disconnect all APIs when done
  * for (const wallet of wallets) {
  *   await wallet.api.disconnect()
@@ -276,39 +276,39 @@ export const mockWallets = async (
 
 /**
  * Retrieves a specific mock wallet by name from a collection of mock wallets.
- * 
+ *
  * This utility function provides easy access to specific development accounts
  * by name, making test code more readable and maintainable. It works with the
  * standard set of development account names.
- * 
+ *
  * @param name - The name of the mock wallet to retrieve (e.g., 'Alice', 'Bob').
  * @param wallets - Array of WalletActivated objects from mockWallets().
  * @returns The WalletActivated object for the specified mock account.
- * 
+ *
  * @example
  * import { mockWallets, getMockWallet } from '@autonomys/auto-utils'
- * 
+ *
  * // Create mock wallets and get specific ones
  * const wallets = await mockWallets({ networkId: 'localhost' })
- * 
+ *
  * const alice = getMockWallet('Alice', wallets)
  * const bob = getMockWallet('Bob', wallets)
  * const charlie = getMockWallet('Charlie', wallets)
- * 
+ *
  * console.log('Alice address:', alice.accounts[0].address)
  * console.log('Bob address:', bob.accounts[0].address)
  * console.log('Charlie address:', charlie.accounts[0].address)
- * 
+ *
  * // Use in tests
  * const sender = getMockWallet('Alice', wallets)
  * const receiver = getMockWallet('Bob', wallets)
- * 
+ *
  * // Perform transfer from Alice to Bob
  * // ... transfer logic here ...
- * 
+ *
  * // Available mock wallet names:
  * // 'Alice', 'Bob', 'Charlie', 'Dave', 'Eve', 'Frank', 'Grace', 'Harry', 'Ivy', 'Jacob'
- * 
+ *
  * @throws {Error} When the specified name is not found in the available mock wallets.
  */
 export const getMockWallet = (name: string, wallets: WalletActivated[]): WalletActivated =>


### PR DESCRIPTION
### Summary
This PR supports the launch of the first mainnet domain (Auto EVM) and comprehensively updates the SDK to reflect the updated network configuration. All documentation examples now showcase mainnet usage instead of deprecated test networks.

### 🎯 Major Changes

#### **🌐 Network Configuration**
- **✅ Added** Auto EVM domain to mainnet network
  - Domain ID: `'0'`
  - RPC endpoint: `wss://auto-evm.mainnet.autonomys.xyz/ws`
- **❌ Removed** Gemini 3h network completely
- 
#### **📚 Documentation Overhaul**
Updated **50+ code examples** across the entire SDK to use `mainnet`:
