### PR TITLE
Align withdrawStake with protocol (shares-only)

### DIFF
--- a/packages/auto-consensus/src/types/staking.ts
+++ b/packages/auto-consensus/src/types/staking.ts
@@ -136,10 +136,7 @@ export type StakingParams = {
 }
 
 export interface WithdrawStakeParams extends StakingParams {
-  all?: boolean
-  percent?: string | number
-  stake?: StringNumberOrBigInt
-  shares?: StringNumberOrBigInt
+  shares: StringNumberOrBigInt
 }
 
 export interface NominateOperatorParams extends StakingParams {


### PR DESCRIPTION
This PR updates the withdrawStake API to match the latest Domains staking protocol, which now only accepts withdrawals strictly in shares.

- Protocol reference: `pallet-domains/src/staking.rs` → do_withdraw_stake() uses shares

### What changed
- Staking API
  - `packages/auto-consensus/src/staking.ts`
    - Simplified `withdrawStake()` to call `api.tx.domains.withdrawStake(operatorId, shares)`
    - Removed legacy variants and helper usage for all/percent/stake modes
    - Updated JSDoc to reflect shares-only semantics
  - `packages/auto-consensus/src/types/staking.ts`
    - `WithdrawStakeParams` now requires `shares: StringNumberOrBigInt`
    - Removed `all`, `percent`, and `stake` fields

### Breaking changes
- `withdrawStake()` no longer supports:
  - `all?: boolean`
  - `percent?: string | number`
  - `stake?: StringNumberOrBigInt`
- Callers must pass `shares`.

### Migration guide
- Withdraw all:
  - Compute from user’s deposit: `shares = deposit.known.shares`
- Withdraw by percentage:
  - `shares = floor(deposit.known.shares * percent / 100)`
- Withdraw by absolute stake:
  - The protocol no longer accepts a stake amount directly. Compute shares off-chain from the user’s current shares (e.g., proportionally if you intend to withdraw an approximate fraction), or expose a shares-based control in the UI.

TypeScript will surface required updates where `WithdrawStakeParams` is used.

### Rationale
- Brings the SDK into parity with protocol changes.
- Reduces client-side ambiguity by standardizing on a single, protocol-native unit (shares).

### Notes
- Deprecated usage of `createWithdrawStakeAll/ByPercent/ByStake/ByShares` in this package.
- No changes to other staking flows or events.

### Example
```ts
withdrawStake({
  api,
  operatorId: '1',
  shares: '50000000000000000000',
})
```