### PR TITLE
fix: content encoding in byte range downloads corrupted body

### DIFF
--- a/packages/utility/file-server/src/http/headers.ts
+++ b/packages/utility/file-server/src/http/headers.ts
@@ -54,7 +54,7 @@ const setFileResponseHeaders = (
   )
   const compressedButNoEncrypted = metadata.isCompressed && !isEncrypted
 
-  if (compressedButNoEncrypted && shouldHandleEncoding && !rawMode) {
+  if (compressedButNoEncrypted && shouldHandleEncoding && !rawMode && !byteRange) {
     res.set('Content-Encoding', 'deflate')
   }
 


### PR DESCRIPTION
There was an edge case when a client fetches partially a file with the flag `ignoreEncoding=false` the responde body would get empty as the client tried to uncompress those bytes that didn't formed a correctly formed compressed chunk. 

I solved this issue by disabling the `Content-Encoding` header when a byte-range is used 