### PR TITLE
feat: add chronos testnet to networks

### DIFF
--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -6,6 +6,7 @@ import { DEFAULT_TOKEN, TESTNET_TOKEN } from './token'
 
 export enum NetworkId {
   MAINNET = 'mainnet',
+  CHRONOS = 'chronos',
   TAURUS = 'taurus',
   DEVNET = 'devnet',
   LOCALHOST = 'localhost',
@@ -13,6 +14,7 @@ export enum NetworkId {
 
 export enum NetworkName {
   MAINNET = 'Mainnet',
+  CHRONOS = 'Testnet - Chronos',
   TAURUS = 'Testnet - Taurus',
   DEVNET = 'Devnet',
   LOCALHOST = 'Localhost',
@@ -25,6 +27,7 @@ export enum NetworkExplorerName {
 
 export const ASTRAL_EXPLORER = 'https://explorer.autonomys.xyz/'
 export const SUBSCAN_EXPLORER = 'https://autonomys.subscan.io/'
+export const SUBSCAN_CHRONOS_EXPLORER = 'https://autonomys-chronos.subscan.io/'
 
 export const networks: Network[] = [
   {
@@ -57,32 +60,35 @@ export const networks: Network[] = [
     token: DEFAULT_TOKEN,
   },
   {
-    id: NetworkId.TAURUS,
-    name: NetworkName.TAURUS,
-    rpcUrls: [
-      'wss://rpc-0.taurus.autonomys.xyz/ws',
-      'wss://rpc-1.taurus.autonomys.xyz/ws',
-      'wss://rpc-0.taurus.subspace.network/ws',
-      'wss://rpc-1.taurus.subspace.network/ws',
-    ],
+    id: NetworkId.CHRONOS,
+    name: NetworkName.CHRONOS,
+    rpcUrls: ['wss://rpc.chronos.autonomys.xyz/ws'],
     explorer: [
       {
-        name: NetworkExplorerName.ASTRAL,
-        url: ASTRAL_EXPLORER + 'taurus/consensus/',
+        name: NetworkExplorerName.SUBSCAN,
+        url: SUBSCAN_CHRONOS_EXPLORER,
       },
     ],
     domains: [
       {
         domainId: '0',
         ...domains[DomainRuntime.AUTO_EVM],
-        rpcUrls: [
-          'wss://auto-evm.taurus.autonomys.xyz/ws',
-          'wss://auto-evm-0.taurus.autonomys.xyz/ws',
-          'wss://auto-evm-1.taurus.autonomys.xyz/ws',
-          'wss://auto-evm.taurus.subspace.network/ws',
-          'wss://auto-evm-0.taurus.subspace.network/ws',
-          'wss://auto-evm-1.taurus.subspace.network/ws',
-        ],
+        rpcUrls: ['wss://auto-evm.chronos.autonomys.xyz/ws'],
+      },
+    ],
+    token: TESTNET_TOKEN,
+    isTestnet: true,
+  },
+  {
+    id: NetworkId.TAURUS,
+    name: NetworkName.TAURUS,
+    rpcUrls: ['wss://rpc-0.taurus.autonomys.xyz/ws'],
+    explorer: [],
+    domains: [
+      {
+        domainId: '0',
+        ...domains[DomainRuntime.AUTO_EVM],
+        rpcUrls: ['wss://auto-evm.taurus.autonomys.xyz/ws'],
       },
     ],
     token: TESTNET_TOKEN,

--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -93,6 +93,7 @@ export const networks: Network[] = [
     ],
     token: TESTNET_TOKEN,
     isTestnet: true,
+    isDeprecated: true,
   },
   {
     id: NetworkId.DEVNET,

--- a/packages/auto-utils/src/network.ts
+++ b/packages/auto-utils/src/network.ts
@@ -38,6 +38,8 @@ import type { DomainParams, NetworkParams } from './types/network'
  *
  * @throws {Error} When the specified networkId is not found in the available networks.
  */
+let hasWarnedDeprecatedOnce = false
+
 export const getNetworkDetails = (input?: NetworkParams) => {
   // If no id is provided, return the default network
   if (!input || !input.networkId) return defaultNetwork
@@ -47,6 +49,15 @@ export const getNetworkDetails = (input?: NetworkParams) => {
   // Find the network with the provided id
   const network = networks.find((network) => network.id === networkId)
   if (!network) throw new Error(`Network with id ${networkId} not found`)
+
+  if (network.isDeprecated && !hasWarnedDeprecatedOnce) {
+    hasWarnedDeprecatedOnce = true
+
+    console.warn(
+      `Warning: Network "${networkId}" is deprecated and will be removed in a future release. ` +
+        'Please migrate to Chronos or Mainnet.',
+    )
+  }
 
   return network
 }

--- a/packages/auto-utils/src/types/network.ts
+++ b/packages/auto-utils/src/types/network.ts
@@ -18,6 +18,7 @@ export type Network = {
   token: Token
   isTestnet?: boolean
   isLocalhost?: boolean
+  isDeprecated?: boolean
 }
 
 export type NetworkParams = { networkId?: string } | undefined


### PR DESCRIPTION
This pull request updates the network configuration in the `auto-utils` package to introduce the Chronos testnet and deprecate the Taurus testnet. The changes reorganize network definitions, add new RPC and explorer URLs for Chronos, and introduce a deprecation warning for Taurus to guide users toward Chronos or Mainnet.

**Network Configuration Updates:**

* Added Chronos testnet to `NetworkId` and `NetworkName` enums, and defined its RPC and explorer URLs in `network.ts`. [[1]](diffhunk://#diff-4fd2dc1471be3439397f28b938666936f488d249dfbac7440079c77f301f041bR9-R17) [[2]](diffhunk://#diff-4fd2dc1471be3439397f28b938666936f488d249dfbac7440079c77f301f041bR30) [[3]](diffhunk://#diff-4fd2dc1471be3439397f28b938666936f488d249dfbac7440079c77f301f041bL60-R96)
* Updated the `networks` array: Chronos is now included as a testnet with its own configuration, while Taurus is marked as deprecated and its configuration is simplified.

**Deprecation Handling:**

* Added an `isDeprecated` property to the `Network` type to support marking networks as deprecated.
* Implemented a one-time console warning in `getNetworkDetails` when accessing a deprecated network, advising migration to Chronos or Mainnet. [[1]](diffhunk://#diff-6fec4a899c6e3552b5abaff5f7fe7ee8c0c45365dcb1e84226765a9c93d13ac5R41-R42) [[2]](diffhunk://#diff-6fec4a899c6e3552b5abaff5f7fe7ee8c0c45365dcb1e84226765a9c93d13ac5R53-R61)