### PR TITLE
refactor: update network explorer details to remove Astral and cleanup RPCs

### DIFF
--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -21,11 +21,9 @@ export enum NetworkName {
 }
 
 export enum NetworkExplorerName {
-  ASTRAL = 'Astral',
   SUBSCAN = 'Subscan',
 }
 
-export const ASTRAL_EXPLORER = 'https://explorer.autonomys.xyz/'
 export const SUBSCAN_EXPLORER = 'https://autonomys.subscan.io/'
 export const SUBSCAN_CHRONOS_EXPLORER = 'https://autonomys-chronos.subscan.io/'
 
@@ -41,10 +39,6 @@ export const networks: Network[] = [
       'wss://rpc.mainnet.subspace.foundation/ws',
     ],
     explorer: [
-      {
-        name: NetworkExplorerName.ASTRAL,
-        url: ASTRAL_EXPLORER,
-      },
       {
         name: NetworkExplorerName.SUBSCAN,
         url: SUBSCAN_EXPLORER,
@@ -99,17 +93,12 @@ export const networks: Network[] = [
     id: NetworkId.DEVNET,
     name: NetworkName.DEVNET,
     rpcUrls: ['ws://rpc.devnet.subspace.network/ws'],
-    explorer: [
-      {
-        name: NetworkExplorerName.ASTRAL,
-        url: ASTRAL_EXPLORER + '/devnet/consensus/',
-      },
-    ],
+    explorer: [],
     domains: [
       {
         domainId: '0',
         ...domains[DomainRuntime.AUTO_EVM],
-        rpcUrls: ['wss:///nova.devnet.subspace.network/ws'],
+        rpcUrls: ['wss:///auto-evm.devnet.subspace.network/ws'],
       },
       {
         domainId: '1',
@@ -125,12 +114,7 @@ export const networks: Network[] = [
     id: NetworkId.LOCALHOST,
     name: NetworkName.LOCALHOST,
     rpcUrls: ['ws://127.0.0.1:9944/ws'],
-    explorer: [
-      {
-        name: NetworkExplorerName.ASTRAL,
-        url: ASTRAL_EXPLORER + 'localhost/consensus/',
-      },
-    ],
+    explorer: [],
     domains: [
       {
         domainId: '0',

--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -31,13 +31,7 @@ export const networks: Network[] = [
   {
     id: NetworkId.MAINNET,
     name: NetworkName.MAINNET,
-    rpcUrls: [
-      'wss://rpc-0.mainnet.subspace.network/ws',
-      'wss://rpc-1.mainnet.subspace.network/ws',
-      'wss://rpc-0.mainnet.autonomys.xyz/ws',
-      'wss://rpc-1.mainnet.autonomys.xyz/ws',
-      'wss://rpc.mainnet.subspace.foundation/ws',
-    ],
+    rpcUrls: ['wss://rpc.mainnet.autonomys.xyz/ws', 'wss://rpc.mainnet.subspace.foundation/ws'],
     explorer: [
       {
         name: NetworkExplorerName.SUBSCAN,
@@ -92,18 +86,18 @@ export const networks: Network[] = [
   {
     id: NetworkId.DEVNET,
     name: NetworkName.DEVNET,
-    rpcUrls: ['ws://rpc.devnet.subspace.network/ws'],
+    rpcUrls: ['ws://rpc.devnet.autonomys.xyz/ws'],
     explorer: [],
     domains: [
       {
         domainId: '0',
         ...domains[DomainRuntime.AUTO_EVM],
-        rpcUrls: ['wss:///auto-evm.devnet.subspace.network/ws'],
+        rpcUrls: ['wss:///auto-evm.devnet.autonomys.xyz/ws'],
       },
       {
         domainId: '1',
         ...domains[DomainRuntime.AUTO_ID],
-        rpcUrls: ['wss://autoid.devnet.subspace.network/ws'],
+        rpcUrls: ['wss://autoid.devnet.autonomys.xyz/ws'],
       },
     ],
     token: TESTNET_TOKEN,

--- a/packages/auto-utils/src/network.ts
+++ b/packages/auto-utils/src/network.ts
@@ -29,7 +29,7 @@ import type { DomainParams, NetworkParams } from './types/network'
  *
  * // Access network explorers
  * const mainnet = getNetworkDetails({ networkId: 'mainnet' })
- * console.log(mainnet.explorer[0].name) // Output: "Astral"
+ * console.log(mainnet.explorer[0].name) // Output: "Subscan"
  * console.log(mainnet.explorer[0].url) // Output: explorer URL
  *
  * // Check if network is for local development


### PR DESCRIPTION
This pull request updates the network configuration in `packages/auto-utils/src/constants/network.ts` to remove references to the Astral explorer and switch all RPC URLs and explorer endpoints to use the Autonomys and Subscan services. The changes simplify the configuration and ensure consistency across network definitions.

**Network explorer updates:**

* Removed the Astral explorer from the `NetworkExplorerName` enum and all network configurations, leaving only Subscan as the supported explorer.
* Updated the example usage in `packages/auto-utils/src/network.ts` to reference Subscan instead of Astral.

**RPC endpoint changes:**

* Updated `MAINNET` RPC URLs to use only Autonomys and Subspace Foundation endpoints, removing older subspace network URLs.
* Updated `DEVNET` and domain RPC URLs to use Autonomys endpoints instead of subspace network endpoints.

**Configuration simplification:**

* Removed explorer configuration for `DEVNET` and `LOCALHOST` networks, leaving their explorer arrays empty. [[1]](diffhunk://#diff-4fd2dc1471be3439397f28b938666936f488d249dfbac7440079c77f301f041bL101-R100) [[2]](diffhunk://#diff-4fd2dc1471be3439397f28b938666936f488d249dfbac7440079c77f301f041bL128-R111)