### PR TITLE
chore: v1.5.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 Future changes will appear here.
 
 
+
+## [1.5.16] - 2025-09-18
+
+### Features
+
+- enhance totalIssuance function to support domain queries ([#472](https://github.com/autonomys/auto-sdk/pull/472)) [@jfrank-summit](https://github.com/jfrank-summit)
+
+### Code Refactoring
+
+- update network explorer details to remove Astral and cleanup RPCs ([#471](https://github.com/autonomys/auto-sdk/pull/471)) [@jfrank-summit](https://github.com/jfrank-summit)
+
+### Chores
+
+- v1.5.15 ([#470](https://github.com/autonomys/auto-sdk/pull/470)) [@jfrank-summit](https://github.com/jfrank-summit)
+
 ## [1.5.15] - 2025-09-10
 
 ### Features
@@ -28,6 +43,7 @@ Future changes will appear here.
 
 - v1.5.13 ([#461](https://github.com/autonomys/auto-sdk/pull/461)) [@jfrank-summit](https://github.com/jfrank-summit)
 
+
 ## [1.5.13] - 2025-08-08
 
 ### Features
@@ -41,6 +57,7 @@ Future changes will appear here.
 ### Chores
 
 - update dependency @polkadot/extension-inject to ^0.58.9 ([#358](https://github.com/autonomys/auto-sdk/pull/358)) [@renovate[bot]](https://github.com/apps/renovate)
+
 
 
 ## [1.5.12] - 2025-07-29
@@ -58,11 +75,13 @@ Future changes will appear here.
 - update dependency eslint-config-prettier to ^10.1.5 ([#370](https://github.com/autonomys/auto-sdk/pull/370)) [@renovate[bot]](https://github.com/apps/renovate)
 
 
+
 ## [1.5.11] - 2025-07-21
 
 ### Features
 
 - add get node method ([#454](https://github.com/autonomys/auto-sdk/pull/454)) [@clostao](https://github.com/clostao)
+
 
 
 ## [1.5.10] - 2025-07-17
@@ -76,11 +95,13 @@ Future changes will appear here.
 - release v1.5.9 ([#451](https://github.com/autonomys/auto-sdk/pull/451)) [@jfrank-summit](https://github.com/jfrank-summit)
 
 
+
 ## [1.5.9] - 2025-07-15
 
 ### Features
 
 - simplify `nominatorPosition` to use runtime api ([#450](https://github.com/autonomys/auto-sdk/pull/450)) [@jfrank-summit](https://github.com/jfrank-summit)
+
 
 
 ## [1.5.8] - 2025-07-15
@@ -98,11 +119,13 @@ Future changes will appear here.
 - bump version to v1.5.7 ([#445](https://github.com/autonomys/auto-sdk/pull/445)) [@clostao](https://github.com/clostao)
 
 
+
 ## [1.5.7] - 2025-07-09
 
 ### Code Refactoring
 
 - update sdk structure for avoid deps issues ([#443](https://github.com/autonomys/auto-sdk/pull/443)) [@clostao](https://github.com/clostao)
+
 
 
 ## [1.5.6] - 2025-07-08
@@ -116,12 +139,14 @@ Future changes will appear here.
 - v1.5.5 ([#441](https://github.com/autonomys/auto-sdk/pull/441)) [@jfrank-summit](https://github.com/jfrank-summit)
 
 
+
 ## [1.5.5] - 2025-07-02
 
 ### Features
 
 - add headDomainNumber function to retrieve latest block number for a specific domain ([#440](https://github.com/autonomys/auto-sdk/pull/440)) [@jfrank-summit](https://github.com/jfrank-summit)
 - add storage fee refund to pending withdrawals ([#439](https://github.com/autonomys/auto-sdk/pull/439)) [@jfrank-summit](https://github.com/jfrank-summit)
+
 
 
 ## [1.5.4] - 2025-07-01
@@ -133,6 +158,7 @@ Future changes will appear here.
 ### Chores
 
 - v1.5.3 ([#437](https://github.com/autonomys/auto-sdk/pull/437)) [@clostao](https://github.com/clostao)
+
 
 
 ## [1.5.3] - 2025-07-01
@@ -156,6 +182,7 @@ Future changes will appear here.
 - Chore v1.5.2 ([#431](https://github.com/autonomys/auto-sdk/pull/431)) [@clostao](https://github.com/clostao)
 
 
+
 ## [1.5.2] - 2025-06-24
 
 ### Features
@@ -167,6 +194,7 @@ Future changes will appear here.
 - downloads should be perfomed in raw mode ([#430](https://github.com/autonomys/auto-sdk/pull/430)) [@clostao](https://github.com/clostao)
 
 
+
 ## [1.5.1] - 2025-06-19
 
 ### Features
@@ -176,6 +204,7 @@ Future changes will appear here.
 ### Chores
 
 - bump to v1.5.0 ([#426](https://github.com/autonomys/auto-sdk/pull/426)) [@clostao](https://github.com/clostao)
+
 
 
 ## [1.5.0] - 2025-06-13
@@ -195,6 +224,7 @@ Future changes will appear here.
 - v1.4.35 ([#421](https://github.com/autonomys/auto-sdk/pull/421)) [@clostao](https://github.com/clostao)
 
 
+
 ## [1.4.35] - 2025-05-29
 
 ### Features
@@ -204,6 +234,7 @@ Future changes will appear here.
 ### Chores
 
 - bump to v1.4.34 ([#420](https://github.com/autonomys/auto-sdk/pull/420)) [@clostao](https://github.com/clostao)
+
 
 
 ## [1.4.34] - 2025-05-29
@@ -217,6 +248,7 @@ Future changes will appear here.
 - bump version to v1.4.33 ([#418](https://github.com/autonomys/auto-sdk/pull/418)) [@clostao](https://github.com/clostao)
 
 
+
 ## [1.4.33] - 2025-05-28
 
 ### Bug Fixes
@@ -226,6 +258,7 @@ Future changes will appear here.
 ### Chores
 
 - v1.4.32 ([#417](https://github.com/autonomys/auto-sdk/pull/417)) [@clostao](https://github.com/clostao)
+
 
 
 ## [1.4.32] - 2025-05-28
@@ -343,6 +376,7 @@ Future changes will appear here.
 - Update dependency cache-manager to ^6.4.2 ([#365](https://github.com/autonomys/auto-sdk/pull/365)) [@renovate[bot]](https://github.com/apps/renovate)
 
 
+
 ## [1.4.31] - 2025-05-14
 
 ### Features
@@ -357,6 +391,8 @@ Future changes will appear here.
 [1.5.13]: https://github.com/autonomys/auto-sdk/compare/v1.5.12...v1.5.13
 [1.5.12]: https://github.com/autonomys/auto-sdk/releases/tag/v1.5.12
 
-[Unreleased]: https://github.com/autonomys/auto-sdk/compare/v1.5.15...HEAD
-[1.5.15]: https://github.com/autonomys/auto-sdk/compare/v1.5.14...v1.5.15
 [1.5.14]: https://github.com/autonomys/auto-sdk/releases/tag/v1.5.14
+
+[Unreleased]: https://github.com/autonomys/auto-sdk/compare/v1.5.16...HEAD
+[1.5.16]: https://github.com/autonomys/auto-sdk/compare/v1.5.15...v1.5.16
+[1.5.15]: https://github.com/autonomys/auto-sdk/releases/tag/v1.5.15

--- a/examples/auto-drive-create-next-app/package.json
+++ b/examples/auto-drive-create-next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-next-app",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/next/package-lock.json
+++ b/examples/next/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next",
-      "version": "1.5.15",
+      "version": "1.5.16",
       "dependencies": {
         "next": "14.2.4",
         "react": "^18",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-sdk-next-example",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "private": true,
   "license": "MIT",
   "packageManager": "yarn@4.2.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "npmClient": "yarn"
 }

--- a/packages/auto-agents/package.json
+++ b/packages/auto-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-agents",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",
@@ -26,8 +26,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-dag-data": "^1.5.15",
-    "@autonomys/auto-drive": "^1.5.15",
+    "@autonomys/auto-dag-data": "^1.5.16",
+    "@autonomys/auto-drive": "^1.5.16",
     "ethers": "6.13.5"
   },
   "devDependencies": {

--- a/packages/auto-consensus/package.json
+++ b/packages/auto-consensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-consensus",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-utils": "^1.5.15"
+    "@autonomys/auto-utils": "^1.5.16"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/auto-dag-data/package.json
+++ b/packages/auto-dag-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-dag-data",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "main": "dist/index.js",
   "type": "module",
@@ -40,7 +40,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.5.15",
+    "@autonomys/asynchronous": "^1.5.16",
     "@ipld/dag-pb": "^4.1.3",
     "@peculiar/webcrypto": "^1.5.0",
     "@webbuf/blake3": "^3.0.26",

--- a/packages/auto-design-system/package.json
+++ b/packages/auto-design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-design-system",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "description": "Autonomys Design System",
   "type": "module",
@@ -34,7 +34,7 @@
     "shadcn": "npx shadcn-ui@latest add"
   },
   "dependencies": {
-    "@autonomys/design-tokens": "^1.5.15",
+    "@autonomys/design-tokens": "^1.5.16",
     "@floating-ui/react": "^0.27.8",
     "@headlessui/react": "^2.2.3",
     "@heroicons/react": "^2.2.0",

--- a/packages/auto-drive/package.json
+++ b/packages/auto-drive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-drive",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,9 +42,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.5.15",
-    "@autonomys/auto-dag-data": "^1.5.15",
-    "@autonomys/auto-utils": "^1.5.15",
+    "@autonomys/asynchronous": "^1.5.16",
+    "@autonomys/auto-dag-data": "^1.5.16",
+    "@autonomys/auto-utils": "^1.5.16",
     "blockstore-core": "^5.0.2",
     "jszip": "^3.10.1",
     "mime-types": "^3.0.1",

--- a/packages/auto-files/package.json
+++ b/packages/auto-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-files",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "packageManager": "yarn@4.7.0",
   "scripts": {
     "build": "tsc"
@@ -21,6 +21,6 @@
     }
   },
   "dependencies": {
-    "@autonomys/auto-drive": "^1.5.15"
+    "@autonomys/auto-drive": "^1.5.16"
   }
 }

--- a/packages/auto-mcp-servers/package.json
+++ b/packages/auto-mcp-servers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/auto-mcp-servers",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "Autonomys Network MCP servers",
   "repository": {
     "type": "git",
@@ -31,8 +31,8 @@
     "server"
   ],
   "dependencies": {
-    "@autonomys/auto-agents": "^1.5.15",
-    "@autonomys/auto-drive": "^1.5.15",
+    "@autonomys/auto-agents": "^1.5.16",
+    "@autonomys/auto-drive": "^1.5.16",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "zod": "^3.24.2"
   },

--- a/packages/auto-utils/package.json
+++ b/packages/auto-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-utils",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/packages/auto-xdm/package.json
+++ b/packages/auto-xdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/auto-xdm",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -25,8 +25,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-consensus": "^1.5.15",
-    "@autonomys/auto-utils": "^1.5.15"
+    "@autonomys/auto-consensus": "^1.5.16",
+    "@autonomys/auto-utils": "^1.5.16"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/utility/asynchronous/package.json
+++ b/packages/utility/asynchronous/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/asynchronous",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/utility/contracts/package.json
+++ b/packages/utility/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/contracts",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/packages/utility/design-tokens/package.json
+++ b/packages/utility/design-tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/design-tokens",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "Auto Design Tokens",
   "type": "module",
   "license": "MIT",

--- a/packages/utility/file-server/package.json
+++ b/packages/utility/file-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/file-server",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "type": "module",
   "repository": {
@@ -47,9 +47,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.5.15",
-    "@autonomys/auto-dag-data": "^1.5.15",
-    "@autonomys/auto-utils": "^1.5.15",
+    "@autonomys/asynchronous": "^1.5.16",
+    "@autonomys/auto-dag-data": "^1.5.16",
+    "@autonomys/auto-utils": "^1.5.16",
     "@keyvhq/sqlite": "^2.1.7",
     "cache-manager": "^6.4.2",
     "express": "^4.19.2",

--- a/packages/utility/rpc/package.json
+++ b/packages/utility/rpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@autonomys/rpc",
   "packageManager": "yarn@4.7.0",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/autonomys/auto-sdk"

--- a/packages/utility/user-session/package.json
+++ b/packages/utility/user-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/user-session",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {
@@ -31,9 +31,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@autonomys/asynchronous": "^1.5.15",
-    "@autonomys/auto-dag-data": "^1.5.15",
-    "@autonomys/auto-drive": "^1.5.15",
+    "@autonomys/asynchronous": "^1.5.16",
+    "@autonomys/auto-dag-data": "^1.5.16",
+    "@autonomys/auto-drive": "^1.5.16",
     "ethers": "6.13.5"
   },
   "gitHead": "ef4c21d683cad697f7015e52becd399a8ca2ed84"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@autonomys/asynchronous@npm:^1.5.15, @autonomys/asynchronous@workspace:packages/utility/asynchronous":
+"@autonomys/asynchronous@npm:^1.5.16, @autonomys/asynchronous@workspace:packages/utility/asynchronous":
   version: 0.0.0-use.local
   resolution: "@autonomys/asynchronous@workspace:packages/utility/asynchronous"
   dependencies:
@@ -45,12 +45,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-agents@npm:^1.5.15, @autonomys/auto-agents@workspace:packages/auto-agents":
+"@autonomys/auto-agents@npm:^1.5.16, @autonomys/auto-agents@workspace:packages/auto-agents":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-agents@workspace:packages/auto-agents"
   dependencies:
-    "@autonomys/auto-dag-data": "npm:^1.5.15"
-    "@autonomys/auto-drive": "npm:^1.5.15"
+    "@autonomys/auto-dag-data": "npm:^1.5.16"
+    "@autonomys/auto-drive": "npm:^1.5.16"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     ethers: "npm:6.13.5"
@@ -61,11 +61,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-consensus@npm:^1.5.15, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
+"@autonomys/auto-consensus@npm:^1.5.16, @autonomys/auto-consensus@workspace:*, @autonomys/auto-consensus@workspace:packages/auto-consensus":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-consensus@workspace:packages/auto-consensus"
   dependencies:
-    "@autonomys/auto-utils": "npm:^1.5.15"
+    "@autonomys/auto-utils": "npm:^1.5.16"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     jest: "npm:^29.7.0"
@@ -75,11 +75,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-dag-data@npm:^1.5.15, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
+"@autonomys/auto-dag-data@npm:^1.5.16, @autonomys/auto-dag-data@workspace:packages/auto-dag-data":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-dag-data@workspace:packages/auto-dag-data"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.5.15"
+    "@autonomys/asynchronous": "npm:^1.5.16"
     "@ipld/dag-pb": "npm:^4.1.3"
     "@peculiar/webcrypto": "npm:^1.5.0"
     "@types/jest": "npm:^29.5.14"
@@ -103,7 +103,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-design-system@workspace:packages/auto-design-system"
   dependencies:
-    "@autonomys/design-tokens": "npm:^1.5.15"
+    "@autonomys/design-tokens": "npm:^1.5.16"
     "@babel/core": "npm:^7.27.1"
     "@babel/preset-env": "npm:^7.27.2"
     "@babel/preset-react": "npm:^7.27.1"
@@ -172,13 +172,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-drive@npm:^1.5.15, @autonomys/auto-drive@workspace:*, @autonomys/auto-drive@workspace:packages/auto-drive":
+"@autonomys/auto-drive@npm:^1.5.16, @autonomys/auto-drive@workspace:*, @autonomys/auto-drive@workspace:packages/auto-drive":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-drive@workspace:packages/auto-drive"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.5.15"
-    "@autonomys/auto-dag-data": "npm:^1.5.15"
-    "@autonomys/auto-utils": "npm:^1.5.15"
+    "@autonomys/asynchronous": "npm:^1.5.16"
+    "@autonomys/auto-dag-data": "npm:^1.5.16"
+    "@autonomys/auto-utils": "npm:^1.5.16"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"
     "@rollup/plugin-json": "npm:^6.1.0"
@@ -202,7 +202,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-files@workspace:packages/auto-files"
   dependencies:
-    "@autonomys/auto-drive": "npm:^1.5.15"
+    "@autonomys/auto-drive": "npm:^1.5.16"
     typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
@@ -211,8 +211,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-mcp-servers@workspace:packages/auto-mcp-servers"
   dependencies:
-    "@autonomys/auto-agents": "npm:^1.5.15"
-    "@autonomys/auto-drive": "npm:^1.5.15"
+    "@autonomys/auto-agents": "npm:^1.5.16"
+    "@autonomys/auto-drive": "npm:^1.5.16"
     "@modelcontextprotocol/sdk": "npm:^1.9.0"
     "@types/node": "npm:22.14.0"
     ts-node: "npm:^10.9.1"
@@ -246,7 +246,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-utils@npm:^1.5.15, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
+"@autonomys/auto-utils@npm:^1.5.16, @autonomys/auto-utils@workspace:*, @autonomys/auto-utils@workspace:packages/auto-utils":
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-utils@workspace:packages/auto-utils"
   dependencies:
@@ -268,8 +268,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/auto-xdm@workspace:packages/auto-xdm"
   dependencies:
-    "@autonomys/auto-consensus": "npm:^1.5.15"
-    "@autonomys/auto-utils": "npm:^1.5.15"
+    "@autonomys/auto-consensus": "npm:^1.5.16"
+    "@autonomys/auto-utils": "npm:^1.5.16"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.25.1"
     jest: "npm:^29.7.0"
@@ -291,7 +291,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/design-tokens@npm:^1.5.15, @autonomys/design-tokens@workspace:packages/utility/design-tokens":
+"@autonomys/design-tokens@npm:^1.5.16, @autonomys/design-tokens@workspace:packages/utility/design-tokens":
   version: 0.0.0-use.local
   resolution: "@autonomys/design-tokens@workspace:packages/utility/design-tokens"
   dependencies:
@@ -314,9 +314,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/file-server@workspace:packages/utility/file-server"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.5.15"
-    "@autonomys/auto-dag-data": "npm:^1.5.15"
-    "@autonomys/auto-utils": "npm:^1.5.15"
+    "@autonomys/asynchronous": "npm:^1.5.16"
+    "@autonomys/auto-dag-data": "npm:^1.5.16"
+    "@autonomys/auto-utils": "npm:^1.5.16"
     "@keyvhq/sqlite": "npm:^2.1.7"
     "@prerenderer/rollup-plugin": "npm:^0.3.12"
     "@rollup/plugin-commonjs": "npm:^28.0.3"
@@ -359,9 +359,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@autonomys/user-session@workspace:packages/utility/user-session"
   dependencies:
-    "@autonomys/asynchronous": "npm:^1.5.15"
-    "@autonomys/auto-dag-data": "npm:^1.5.15"
-    "@autonomys/auto-drive": "npm:^1.5.15"
+    "@autonomys/asynchronous": "npm:^1.5.16"
+    "@autonomys/auto-dag-data": "npm:^1.5.16"
+    "@autonomys/auto-drive": "npm:^1.5.16"
     eslint: "npm:^9.25.1"
     ethers: "npm:6.13.5"
     prettier: "npm:^3.5.3"


### PR DESCRIPTION
New version released, feature and refactoring highlights:

* Enhanced the `totalIssuance` function to support domain queries.
* Refactored network explorer details to remove Astral and cleaned up RPCs.
