### PR TITLE
feat: add transactionByteFee function and schema

### DIFF
--- a/packages/auto-consensus/src/index.ts
+++ b/packages/auto-consensus/src/index.ts
@@ -8,6 +8,7 @@ export * from './info'
 export * from './position'
 export * from './remark'
 export * from './staking'
+export * from './transactionFees'
 export * from './transfer'
 
 export * from './types'

--- a/packages/auto-consensus/src/transactionFees.ts
+++ b/packages/auto-consensus/src/transactionFees.ts
@@ -1,0 +1,18 @@
+import { ApiPromise } from '@polkadot/api'
+import { z } from 'zod'
+
+const TransactionByteFeeSchema = z.object({
+  current: z.number(),
+  next: z.number(),
+})
+
+export const transactionByteFee = async (api: ApiPromise) => {
+  await api.isReady
+
+  // Query transactionFees.transactionByteFee
+  const transactionByteFee = await api.query.transactionFees
+    .transactionByteFee()
+    .then((v) => TransactionByteFeeSchema.parse(v.toJSON()))
+
+  return transactionByteFee
+}


### PR DESCRIPTION
## Description

Adds support for calling the state query `transactionFees.transactionByteFee`