### PR TITLE
chore: add zod dependency to auto-consensus package and update yarn.lock

### DIFF
--- a/packages/auto-consensus/package.json
+++ b/packages/auto-consensus/package.json
@@ -25,7 +25,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@autonomys/auto-utils": "^1.5.19"
+    "@autonomys/auto-utils": "^1.5.19",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,7 @@ __metadata:
     prettier: "npm:^3.5.3"
     ts-jest: "npm:^29.3.1"
     typescript: "npm:^5.8.3"
+    zod: "npm:^3.24.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This pull request makes a minor update to the `packages/auto-consensus/package.json` file by adding a missing dependency on zod. Closes #480 
