### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
-/.github/workflows                @clostao @jfrank-summit
+/.github/workflows                @jfrank-summit
 /packages/auto-consensus          @jfrank-summit
-/packages/auto-dag-data           @clostao
-/packages/auto-drive              @clostao
+/packages/auto-dag-data           @jfrank-summit
+/packages/auto-drive              @jfrank-summit
 /packages/auto-utils              @jfrank-summit
 /packages/auto-xdm                @jfrank-summit
-/packages/utility/asynchronous    @clostao
-/packages/utility/file-caching    @clostao
-/packages/utility/rpc             @clostao
+/packages/utility/asynchronous    @jfrank-summit
+/packages/utility/file-caching    @jfrank-summit
+/packages/utility/rpc             @jfrank-summit
 /packages/utility/user-session    @jfrank-summit


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to reassign ownership of auto-sdk packages. 