### PR TITLE
fix: remove object fallback to prevent auto-downloads (#505)

### DIFF
--- a/packages/auto-design-system/src/components/common/FilePreview/FilePreview.tsx
+++ b/packages/auto-design-system/src/components/common/FilePreview/FilePreview.tsx
@@ -263,27 +263,16 @@ export const FilePreview = ({
       )
     }
 
-    const sanitizedFileName = fileData.fileName ? sanitizeHTML(fileData.fileName) : undefined
-
     return (
-      <div className='flex flex-col items-center'>
-        <object
-          className='h-[50vh] w-full border dark:border-gray-700'
-          data={fileData.uri}
-          type={fileData.fileType}
-          aria-label={sanitizedFileName}
-          title={sanitizedFileName}
-        />
-        <div className='mt-4 text-sm text-gray-500 dark:text-gray-400'>
-          {fileData.fileType || extension.toUpperCase()} file preview
-        </div>
+      <>
+        <NoPreviewAvailable />
         <DirectGatewayLink
           gatewayUrl={gatewayUrl}
           isEncrypted={!!metadata.uploadOptions?.encryption}
           isAutoDrive={isAutoDrive}
           isAstral={isAstral}
         />
-      </div>
+      </>
     )
   }
 


### PR DESCRIPTION
This PR:
- Replaces the <object> fallback in FilePreview with NoPreviewAvailable + DirectGatewayLink.
- Prevents browsers from auto-downloading/embedding unknown types (e.g., .enc, .bin, .dat).
- Keeps existing previews for supported types (image/video/audio/PDF/text/JSON) unchanged.
- Removes the now-unused sanitizedFileName variable.
