### PR TITLE
chore: add publishConfig for wallet packages

### DIFF
--- a/packages/auto-wallet-react/package.json
+++ b/packages/auto-wallet-react/package.json
@@ -22,6 +22,9 @@
   "bugs": {
     "url": "https://github.com/autonomys/auto-sdk/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rollup -c",
     "prebuild": "rm -rf dist",

--- a/packages/auto-wallet/package.json
+++ b/packages/auto-wallet/package.json
@@ -16,6 +16,9 @@
   "bugs": {
     "url": "https://github.com/autonomys/auto-sdk/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Summary
- Adds `"publishConfig": { "access": "public" }` to `@autonomys/auto-wallet` and `@autonomys/auto-wallet-react` package.json files
- Scoped npm packages default to restricted access on first publish, causing `E402 "You must sign up for private packages"` during the release workflow
- This was the cause of the failed release runs: https://github.com/autonomys/auto-sdk/actions/runs/21885211777

## Test plan
- [ ] Merge to main and re-run the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)