### PR TITLE
chore: bump lerna version to 1.6.8 for clean 1.6.9 release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.6.6",
+  "version": "1.6.8",
   "npmClient": "yarn"
 }


### PR DESCRIPTION
## Summary
- Bumps `lerna.json` version from `1.6.6` to `1.6.8` so the next release publishes `1.6.9`
- Version `1.6.7` was successfully published; `1.6.8` was partially published during failed release attempts due to NPM key expiry
- Deleted stale `v1.6.8` git tag that was blocking releases

## Test plan
- [ ] Merge this PR
- [ ] Run the release workflow — should publish `1.6.9` across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)