### PR TITLE
fix: wallet name misidentification

### DIFF
--- a/packages/auto-wallet/src/connect.ts
+++ b/packages/auto-wallet/src/connect.ts
@@ -1,21 +1,29 @@
 import { getWalletBySource } from '@talismn/connect-wallets';
+import type { Wallet } from '@talismn/connect-wallets';
 import { address } from '@autonomys/auto-utils';
 import type { WalletConfig } from './types';
 
 /**
  * Core wallet connection logic. Connects to a browser wallet extension,
  * enables it, fetches accounts, and converts addresses to the configured SS58 format.
+ *
+ * @param extensionName - The wallet extension name (e.g. 'polkadot-js')
+ * @param config - Resolved wallet configuration
+ * @param resolvedWallet - Optional pre-resolved wallet object. When provided, this wallet is used
+ *   directly instead of looking up by extensionName. This avoids ambiguity when multiple wallet
+ *   classes share the same extensionName (e.g. NovaWallet and PolkadotjsWallet both use 'polkadot-js').
  */
 export const connectToWallet = async (
   extensionName: string,
   config: Required<WalletConfig>,
+  resolvedWallet?: Wallet,
 ) => {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => reject(new Error('Connection timeout')), config.connectionTimeout);
   });
 
-  const wallet = getWalletBySource(extensionName);
+  const wallet = resolvedWallet ?? getWalletBySource(extensionName);
   if (!wallet) {
     clearTimeout(timeoutId);
     throw new Error(`Wallet not found: ${extensionName}`);

--- a/packages/auto-wallet/src/connect.ts
+++ b/packages/auto-wallet/src/connect.ts
@@ -47,7 +47,7 @@ export const connectToWallet = async (
 
   const rawAccounts = await wallet.getAccounts();
   if (!rawAccounts || rawAccounts.length === 0) {
-    throw new Error(`No accounts found in ${wallet.title}. Please create an account first.`);
+    throw new Error(`No accounts found in ${wallet.title}. Please create or connect an account first.`);
   }
 
   // Convert all account addresses to the configured SS58 format

--- a/packages/auto-wallet/src/store.ts
+++ b/packages/auto-wallet/src/store.ts
@@ -63,7 +63,7 @@ export function createWalletStore(userConfig?: Partial<WalletConfig>) {
         },
 
         connectWallet: async (extensionName: string) => {
-          const { isLoading } = get();
+          const { isLoading, availableWallets } = get();
 
           // Prevent multiple simultaneous connection attempts
           if (isLoading) {
@@ -79,7 +79,12 @@ export function createWalletStore(userConfig?: Partial<WalletConfig>) {
           });
 
           try {
-            const { accounts, injector } = await connectToWallet(extensionName, config);
+            // Use the wallet from our filtered availableWallets list to avoid ambiguity
+            // when multiple wallet classes share the same extensionName (e.g. Nova and Polkadot.js)
+            const resolvedWallet = availableWallets.find(
+              (w) => w.extensionName === extensionName,
+            );
+            const { accounts, injector } = await connectToWallet(extensionName, config, resolvedWallet);
 
             // If a newer connection was started or user disconnected, discard this result
             if (get()._connectionSeq !== seq) {
@@ -135,9 +140,13 @@ export function createWalletStore(userConfig?: Partial<WalletConfig>) {
           });
 
           try {
-            // Check if wallet is still installed before attempting connection
-            const wallet = getWalletBySource(selectedWallet);
-            if (!wallet?.installed) {
+            // Use the wallet from our filtered availableWallets list to avoid ambiguity
+            // when multiple wallet classes share the same extensionName
+            const { availableWallets } = get();
+            const resolvedWallet = availableWallets.find(
+              (w) => w.extensionName === selectedWallet,
+            ) ?? getWalletBySource(selectedWallet);
+            if (!resolvedWallet?.installed) {
               // Clear invalid persisted data
               console.log('Wallet no longer installed, clearing persisted data');
               set({
@@ -150,7 +159,7 @@ export function createWalletStore(userConfig?: Partial<WalletConfig>) {
               return;
             }
 
-            const { accounts, injector } = await connectToWallet(selectedWallet, config);
+            const { accounts, injector } = await connectToWallet(selectedWallet, config, resolvedWallet);
 
             // If a newer connection was started or user disconnected, discard this result
             if (get()._connectionSeq !== seq) {


### PR DESCRIPTION
## Summary

- **Bug**: When a user connects via Polkadot.js and has no accounts, the error says "No accounts found in **Nova Wallet**" — even without Nova Wallet installed
- **Root cause**: `NovaWallet` and `PolkadotjsWallet` in `@talismn/connect-wallets` both use `extensionName = 'polkadot-js'`. Since `NovaWallet` appears first in the array, `getWalletBySource('polkadot-js')` always returns the Nova entry. `detectWallets` correctly filters Nova out of the UI, but `connectToWallet` did its own independent lookup and hit Nova instead.
- **Fix**: Pass the already-filtered wallet object from `availableWallets` into `connectToWallet`, so the connection uses the same wallet the UI displayed. Falls back to `getWalletBySource` only when `availableWallets` isn't populated (e.g. during rehydration).

## Test plan

- [x] Install Polkadot.js extension with **no accounts**, connect via beneficiary portal → error should say "Polkadot.js" not "Nova Wallet"
- [x] Install Polkadot.js extension with accounts, connect → should work as before
- [x] Test wallet reconnection on page reload (rehydration path)
- [x] Verify Talisman and SubWallet connections still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)