### PR TITLE
feat(auto-drive): add Pay with AI3 payment intent methods

### DIFF
--- a/packages/auto-drive/README.md
+++ b/packages/auto-drive/README.md
@@ -316,9 +316,10 @@ try {
 
 Storage on the Autonomys Network is paid for with AI3 tokens via an on-chain payment intent flow. The SDK handles all of the Auto Drive API interactions; you supply the on-chain transaction using your preferred EVM wallet library (wagmi, viem, ethers, etc.).
 
-#### The four-step flow
+#### The flow
 
 ```
+0. getStoragePrice(api)                  → optional: show live price estimate before payment
 1. createPaymentIntent(api, sizeBytes)   → locks price, returns amount + contract details
 2. send ai3AmountWei to contractAddress  → payIntent(intentId) on-chain (your wallet code)
 3. watchPaymentTransaction(api, id, tx)  → notifies Auto Drive of your tx hash
@@ -327,7 +328,18 @@ Storage on the Autonomys Network is paid for with AI3 tokens via an on-chain pay
 
 #### Important: keep your API key server-side
 
-`createPaymentIntent`, `watchPaymentTransaction`, and `getPaymentIntentStatus` all require an API key. In a web application these calls must be made from your server (e.g. a Next.js API route, an Express handler), not from the browser. `getPaymentContractInfo` is a public endpoint and can be called from anywhere.
+`createPaymentIntent`, `watchPaymentTransaction`, and `getPaymentIntentStatus` all require an API key. In a web application these calls must be made from your server (e.g. a Next.js API route, an Express handler), not from the browser. `getStoragePrice` and `getPaymentContractInfo` are public endpoints and can be called from anywhere.
+
+#### Getting a live price estimate
+
+```typescript
+// Public endpoint — no API key required. Good for showing a cost estimate
+// before the user connects a wallet or commits to a payment.
+const publicApi = createAutoDriveApi({ apiKey: null, network: NetworkId.MAINNET })
+const { shannonsPerByte, ai3PerGb } = await publicApi.getStoragePrice()
+
+console.log(`Current price: ${ai3PerGb} AI3/GB`)
+```
 
 #### Server-side example (Node / Next.js API route)
 

--- a/packages/auto-drive/README.md
+++ b/packages/auto-drive/README.md
@@ -312,6 +312,96 @@ try {
 }
 ```
 
+### Pay with AI3 — purchasing storage credits
+
+Storage on the Autonomys Network is paid for with AI3 tokens via an on-chain payment intent flow. The SDK handles all of the Auto Drive API interactions; you supply the on-chain transaction using your preferred EVM wallet library (wagmi, viem, ethers, etc.).
+
+#### The four-step flow
+
+```
+1. createPaymentIntent(api, sizeBytes)   → locks price, returns amount + contract details
+2. send ai3AmountWei to contractAddress  → payIntent(intentId) on-chain (your wallet code)
+3. watchPaymentTransaction(api, id, tx)  → notifies Auto Drive of your tx hash
+4. waitForPaymentCompletion(api, id)     → polls until COMPLETED (credits applied)
+```
+
+#### Important: keep your API key server-side
+
+`createPaymentIntent`, `watchPaymentTransaction`, and `getPaymentIntentStatus` all require an API key. In a web application these calls must be made from your server (e.g. a Next.js API route, an Express handler), not from the browser. `getPaymentContractInfo` is a public endpoint and can be called from anywhere.
+
+#### Server-side example (Node / Next.js API route)
+
+```typescript
+import { createAutoDriveApi } from '@autonomys/auto-drive'
+import { NetworkId } from '@autonomys/auto-utils'
+
+// Run on your server — never expose your API key to the browser
+const api = createAutoDriveApi({ apiKey: process.env.AUTO_DRIVE_API_KEY!, network: NetworkId.MAINNET })
+
+// Step 1 — create a price-locked intent for the content you want to store
+const intent = await api.createPaymentIntent(contentSizeBytes)
+// intent.ai3AmountWei  — exact amount to send (as a BigInt-safe string)
+// intent.ai3Amount     — human-readable amount, e.g. "0.00123"
+// intent.contractAddress — Credits Receiver contract on Auto EVM
+// intent.intentId      — pass as the bytes32 arg to payIntent()
+// intent.expiresAt     — ISO timestamp, intent expires after 10 minutes
+
+// Step 2 — your client sends the on-chain transaction (see below)
+// const txHash = await walletClient.writeContract({ ... })
+
+// Step 3 — submit the tx hash so Auto Drive can watch it
+await api.watchPaymentTransaction(intent.intentId, txHash)
+
+// Step 4 — poll until credits are applied (or intent expires/fails)
+const result = await api.waitForPaymentCompletion(intent.intentId)
+// result: 'COMPLETED' | 'EXPIRED' | 'FAILED' | 'OVER_CAP'
+
+if (result === 'COMPLETED') {
+  console.log('Credits applied — ready to upload')
+}
+```
+
+#### Client-side example (browser, using viem)
+
+```typescript
+import { createAutoDriveApi } from '@autonomys/auto-drive'
+import { NetworkId } from '@autonomys/auto-utils'
+import { createWalletClient, custom, parseGwei } from 'viem'
+
+// Step 1 — fetch contract details (public endpoint, no API key needed)
+const publicApi = createAutoDriveApi({ apiKey: null, network: NetworkId.MAINNET })
+const contractInfo = await publicApi.getPaymentContractInfo()
+
+// Step 2 — send the on-chain transaction with your wallet
+const walletClient = createWalletClient({ transport: custom(window.ethereum) })
+const [account] = await walletClient.requestAddresses()
+
+const txHash = await walletClient.writeContract({
+  address: contractInfo.contractAddress as `0x${string}`,
+  abi: contractInfo.payIntentAbi,
+  functionName: 'payIntent',
+  args: [intent.intentId as `0x${string}`],
+  value: BigInt(intent.ai3AmountWei),
+})
+// Then call your server route to run steps 3 and 4
+```
+
+#### Polling with custom options
+
+```typescript
+const result = await api.waitForPaymentCompletion(intent.intentId, {
+  pollIntervalMs: 5_000,  // check every 5 seconds (default: 3 000)
+  timeoutMs: 120_000,     // give up after 2 minutes (default: 300 000)
+})
+```
+
+#### Checking intent status manually
+
+```typescript
+const { id, status } = await api.getPaymentIntentStatus(intent.intentId)
+// status: 'PENDING' | 'CONFIRMED' | 'COMPLETED' | 'EXPIRED' | 'FAILED' | 'OVER_CAP'
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/packages/auto-drive/src/api/calls/index.ts
+++ b/packages/auto-drive/src/api/calls/index.ts
@@ -1,11 +1,23 @@
 import * as downloadCalls from './download'
+import * as paymentCalls from './payment'
 import * as readCalls from './read'
 import * as uploadCalls from './upload'
 import * as writeCalls from './write'
 
 export const apiCalls = {
   ...downloadCalls,
+  ...paymentCalls,
   ...readCalls,
   ...uploadCalls,
   ...writeCalls,
 }
+
+// Re-export payment utilities as named exports so callers can use them
+// as standalone functions without going through the apiCalls object.
+export {
+  getPaymentContractInfo,
+  createPaymentIntent,
+  watchPaymentTransaction,
+  getPaymentIntentStatus,
+  waitForPaymentCompletion,
+} from './payment'

--- a/packages/auto-drive/src/api/calls/index.ts
+++ b/packages/auto-drive/src/api/calls/index.ts
@@ -15,6 +15,7 @@ export const apiCalls = {
 // Re-export payment utilities as named exports so callers can use them
 // as standalone functions without going through the apiCalls object.
 export {
+  getStoragePrice,
   getPaymentContractInfo,
   createPaymentIntent,
   watchPaymentTransaction,

--- a/packages/auto-drive/src/api/calls/payment.ts
+++ b/packages/auto-drive/src/api/calls/payment.ts
@@ -40,6 +40,11 @@ export const getPaymentContractInfo = async (
  * The returned `ai3AmountWei` is the exact value to pass as `msg.value`
  * when calling `payIntent(intentId)` on the Credits Receiver contract.
  *
+ * Note: `sizeBytes` is **not** sent to the Auto Drive API. The POST `/intents`
+ * endpoint accepts no request body — it returns the current `shannonsPerByte`
+ * rate. This function multiplies that rate by `sizeBytes` locally to produce
+ * `ai3AmountWei`, saving the caller from doing the BigInt arithmetic themselves.
+ *
  * Flow:
  * 1. Call `createPaymentIntent(api, sizeBytes)` — locks the price
  * 2. Send `intent.ai3AmountWei` to `intent.contractAddress` via `payIntent(intent.intentId)`

--- a/packages/auto-drive/src/api/calls/payment.ts
+++ b/packages/auto-drive/src/api/calls/payment.ts
@@ -1,0 +1,153 @@
+import { shannonsToAi3 } from '@autonomys/auto-utils'
+import {
+  PaymentContractInfo,
+  PaymentIntent,
+  PaymentIntentStatus,
+  PaymentIntentTerminalStatus,
+  PollOptions,
+} from '../models/payment'
+import { AutoDriveApiHandler } from '../types'
+
+const TERMINAL_STATUSES: PaymentIntentTerminalStatus[] = [
+  'COMPLETED',
+  'EXPIRED',
+  'FAILED',
+  'OVER_CAP',
+]
+
+/**
+ * Fetches the EVM chain ID, contract address, and ABI needed to call `payIntent(bytes32)`.
+ *
+ * This is a public endpoint — no API key is required. The result is stable
+ * per network and safe to cache for the lifetime of the application.
+ */
+export const getPaymentContractInfo = async (
+  api: AutoDriveApiHandler,
+): Promise<PaymentContractInfo> => {
+  const response = await api.sendAPIRequest('/intents/contract', { method: 'GET' })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch payment contract info: ${response.status} ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+/**
+ * Creates a price-locked payment intent for a given upload size in bytes.
+ *
+ * The intent locks the current `shannonsPerByte` price for 10 minutes.
+ * The returned `ai3AmountWei` is the exact value to pass as `msg.value`
+ * when calling `payIntent(intentId)` on the Credits Receiver contract.
+ *
+ * Flow:
+ * 1. Call `createPaymentIntent(api, sizeBytes)` — locks the price
+ * 2. Send `intent.ai3AmountWei` to `intent.contractAddress` via `payIntent(intent.intentId)`
+ * 3. Call `watchPaymentTransaction(api, intent.intentId, txHash)` — submit the tx hash
+ * 4. Call `waitForPaymentCompletion(api, intent.intentId)` — poll until COMPLETED
+ */
+export const createPaymentIntent = async (
+  api: AutoDriveApiHandler,
+  sizeBytes: number,
+): Promise<PaymentIntent> => {
+  const [contractInfo, intentRes] = await Promise.all([
+    getPaymentContractInfo(api),
+    api.sendAPIRequest('/intents', { method: 'POST' }),
+  ])
+
+  if (!intentRes.ok) {
+    const body = await intentRes.text()
+    throw new Error(`Failed to create payment intent: ${intentRes.status} ${body}`)
+  }
+
+  const intent = await intentRes.json()
+  const shannonsPerByte = BigInt(intent.shannonsPerByte)
+  const ai3AmountWei = shannonsPerByte * BigInt(sizeBytes)
+
+  return {
+    intentId: intent.id,
+    ai3AmountWei: ai3AmountWei.toString(),
+    ai3Amount: shannonsToAi3(ai3AmountWei),
+    contractAddress: contractInfo.contractAddress,
+    shannonsPerByte: intent.shannonsPerByte,
+    expiresAt: intent.expiresAt,
+  }
+}
+
+/**
+ * Notifies Auto Drive that an on-chain transaction has been submitted for a payment intent.
+ *
+ * Auto Drive will watch the transaction on-chain and automatically apply storage
+ * credits to your account once the transaction is confirmed.
+ */
+export const watchPaymentTransaction = async (
+  api: AutoDriveApiHandler,
+  intentId: string,
+  txHash: string,
+): Promise<void> => {
+  const response = await api.sendAPIRequest(
+    `/intents/${intentId}/watch`,
+    {
+      method: 'POST',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+    },
+    JSON.stringify({ txHash }),
+  )
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Failed to watch payment transaction: ${response.status} ${body}`)
+  }
+}
+
+/**
+ * Returns the current status of a payment intent.
+ *
+ * Possible statuses: PENDING | CONFIRMED | COMPLETED | EXPIRED | FAILED | OVER_CAP
+ */
+export const getPaymentIntentStatus = async (
+  api: AutoDriveApiHandler,
+  intentId: string,
+): Promise<{ id: string; status: PaymentIntentStatus }> => {
+  const response = await api.sendAPIRequest(`/intents/${intentId}`, { method: 'GET' })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Failed to get payment intent status: ${response.status} ${body}`)
+  }
+
+  const data = await response.json()
+  return { id: data.id, status: data.status.toUpperCase() as PaymentIntentStatus }
+}
+
+/**
+ * Polls a payment intent at regular intervals until it reaches a terminal state.
+ *
+ * Returns the terminal status: COMPLETED | EXPIRED | FAILED | OVER_CAP.
+ * Throws if the timeout is exceeded before a terminal state is reached.
+ *
+ * @param api     - An authenticated AutoDriveApiHandler
+ * @param intentId - The intent ID returned by `createPaymentIntent`
+ * @param options - Optional poll interval and timeout (defaults: 3 s / 5 min)
+ */
+export const waitForPaymentCompletion = async (
+  api: AutoDriveApiHandler,
+  intentId: string,
+  { pollIntervalMs = 3_000, timeoutMs = 300_000 }: PollOptions = {},
+): Promise<PaymentIntentTerminalStatus> => {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    const { status } = await getPaymentIntentStatus(api, intentId)
+
+    if ((TERMINAL_STATUSES as string[]).includes(status)) {
+      return status as PaymentIntentTerminalStatus
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+  }
+
+  throw new Error(
+    `Timed out waiting for payment intent "${intentId}" to complete after ${timeoutMs}ms`,
+  )
+}

--- a/packages/auto-drive/src/api/calls/payment.ts
+++ b/packages/auto-drive/src/api/calls/payment.ts
@@ -42,8 +42,8 @@ export const getPaymentContractInfo = async (
  *
  * Note: `sizeBytes` is **not** sent to the Auto Drive API. The POST `/intents`
  * endpoint accepts no request body — it returns the current `shannonsPerByte`
- * rate. This function multiplies that rate by `sizeBytes` locally to produce
- * `ai3AmountWei`, saving the caller from doing the BigInt arithmetic themselves.
+ * rate. The SDK multiplies that rate by `sizeBytes` to produce `ai3AmountWei`,
+ * saving the caller from doing the BigInt arithmetic themselves.
  *
  * Flow:
  * 1. Call `createPaymentIntent(api, sizeBytes)` — locks the price

--- a/packages/auto-drive/src/api/calls/payment.ts
+++ b/packages/auto-drive/src/api/calls/payment.ts
@@ -5,6 +5,7 @@ import {
   PaymentIntentStatus,
   PaymentIntentTerminalStatus,
   PollOptions,
+  StoragePrice,
 } from '../models/payment'
 import { AutoDriveApiHandler } from '../types'
 
@@ -14,6 +15,26 @@ const TERMINAL_STATUSES: PaymentIntentTerminalStatus[] = [
   'FAILED',
   'OVER_CAP',
 ]
+
+/**
+ * Returns the current live storage price without creating a price-locked intent.
+ *
+ * This is a public endpoint — no API key is required.
+ * Use it to show a cost estimate to users before they commit to a payment.
+ *
+ * @returns `shannonsPerByte` — the raw on-chain price, and `ai3PerGb` — a
+ *   pre-computed display value in AI3 per gigabyte.
+ */
+export const getStoragePrice = async (api: AutoDriveApiHandler): Promise<StoragePrice> => {
+  const response = await api.sendAPIRequest('/intents/price', { method: 'GET' })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch storage price: ${response.status} ${response.statusText}`)
+  }
+
+  const { price, pricePerGB } = await response.json()
+  return { shannonsPerByte: price, ai3PerGb: pricePerGB }
+}
 
 /**
  * Fetches the EVM chain ID, contract address, and ABI needed to call `payIntent(bytes32)`.

--- a/packages/auto-drive/src/api/models/index.ts
+++ b/packages/auto-drive/src/api/models/index.ts
@@ -1,2 +1,3 @@
 export * from './objects'
+export * from './payment'
 export * from './uploads'

--- a/packages/auto-drive/src/api/models/payment.ts
+++ b/packages/auto-drive/src/api/models/payment.ts
@@ -1,4 +1,16 @@
 /**
+ * Current storage price, returned by `getStoragePrice`.
+ * This is a live read of the on-chain byte fee — no API key required.
+ * Use it to display a cost estimate before creating a price-locked intent.
+ */
+export type StoragePrice = {
+  /** Current price per byte in shannons */
+  shannonsPerByte: number
+  /** Pre-computed display price in AI3 per gigabyte */
+  ai3PerGb: number
+}
+
+/**
  * Information about the EVM smart contract used to pay for storage intents.
  * Returned by the public `/intents/contract` endpoint — no API key required.
  */

--- a/packages/auto-drive/src/api/models/payment.ts
+++ b/packages/auto-drive/src/api/models/payment.ts
@@ -1,0 +1,55 @@
+/**
+ * Information about the EVM smart contract used to pay for storage intents.
+ * Returned by the public `/intents/contract` endpoint — no API key required.
+ */
+export type PaymentContractInfo = {
+  /** Auto EVM chain ID (870 for mainnet) */
+  chainId: number
+  /** Address of the Credits Receiver contract */
+  contractAddress: string
+  /** ABI fragment for the payIntent(bytes32) function */
+  payIntentAbi: readonly unknown[]
+}
+
+/**
+ * A price-locked payment intent returned by `createPaymentIntent`.
+ * The intent expires after 10 minutes. Send exactly `ai3AmountWei` to
+ * the Credits Receiver contract via `payIntent(intentId)`.
+ */
+export type PaymentIntent = {
+  /** Unique intent identifier — pass as the `bytes32` arg to `payIntent()` */
+  intentId: string
+  /** Amount to send, in shannons/wei, as a decimal string (safe for BigInt conversion) */
+  ai3AmountWei: string
+  /** Human-readable amount, e.g. "0.00123" */
+  ai3Amount: string
+  /** The Credits Receiver contract address (convenience copy from PaymentContractInfo) */
+  contractAddress: string
+  /** Current price per byte in shannons */
+  shannonsPerByte: string
+  /** ISO 8601 timestamp when this intent expires */
+  expiresAt: string
+}
+
+/** All possible states a payment intent can be in */
+export type PaymentIntentStatus =
+  | 'PENDING'
+  | 'CONFIRMED'
+  | 'COMPLETED'
+  | 'EXPIRED'
+  | 'FAILED'
+  | 'OVER_CAP'
+
+/** States that indicate the intent lifecycle has ended */
+export type PaymentIntentTerminalStatus = Extract<
+  PaymentIntentStatus,
+  'COMPLETED' | 'EXPIRED' | 'FAILED' | 'OVER_CAP'
+>
+
+/** Options for `waitForPaymentCompletion` */
+export type PollOptions = {
+  /** How often to check intent status. Default: 3 000 ms */
+  pollIntervalMs?: number
+  /** Maximum time to wait before throwing. Default: 300 000 ms (5 minutes) */
+  timeoutMs?: number
+}

--- a/packages/auto-drive/src/api/types.ts
+++ b/packages/auto-drive/src/api/types.ts
@@ -192,7 +192,7 @@ export interface AutoDriveApi extends AutoDriveApiHandler {
    * `intent.ai3AmountWei` to the Credits Receiver contract via `payIntent(intent.intentId)`,
    * then call `watchPaymentTransaction` to notify Auto Drive.
    *
-   * @param sizeBytes - Upload size in bytes. Used **locally** to compute
+   * @param sizeBytes - Upload size in bytes. Used **by the SDK** to compute
    *   `ai3AmountWei = shannonsPerByte × sizeBytes`. It is not sent to the server —
    *   the POST `/intents` endpoint accepts no request body.
    * @returns {Promise<PaymentIntent>} Intent details including amount, contract address, and expiry.

--- a/packages/auto-drive/src/api/types.ts
+++ b/packages/auto-drive/src/api/types.ts
@@ -2,6 +2,13 @@ import { ObjectSummary } from './models'
 import { AsyncDownload } from './models/asyncDownloads'
 import { PaginatedResult } from './models/common'
 import { GenericFile, GenericFileWithinFolder } from './models/file'
+import {
+  PaymentContractInfo,
+  PaymentIntent,
+  PaymentIntentStatus,
+  PaymentIntentTerminalStatus,
+  PollOptions,
+} from './models/payment'
 import { SubscriptionInfo, UserInfo } from './models/user'
 import { AutoDriveNetwork } from './networks'
 
@@ -163,6 +170,67 @@ export interface AutoDriveApi extends AutoDriveApiHandler {
    * @returns {Promise<SubscriptionInfo>} A promise that resolves to the subscription info.
    */
   getSubscriptionInfo: () => Promise<SubscriptionInfo>
+
+  // ---------------------------------------------------------------------------
+  // Pay with AI3 — credit purchase via on-chain payment intent
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetches the EVM chain ID, contract address, and ABI for the Credits Receiver contract.
+   *
+   * This is a public endpoint — no API key required. The result is stable per network
+   * and safe to cache for the lifetime of the application.
+   *
+   * @returns {Promise<PaymentContractInfo>} Chain details needed to call `payIntent(bytes32)`.
+   */
+  getPaymentContractInfo: () => Promise<PaymentContractInfo>
+
+  /**
+   * Creates a price-locked payment intent for a given upload size.
+   *
+   * The intent locks the current storage price for 10 minutes. Send exactly
+   * `intent.ai3AmountWei` to the Credits Receiver contract via `payIntent(intent.intentId)`,
+   * then call `watchPaymentTransaction` to notify Auto Drive.
+   *
+   * @param sizeBytes - The size of the content to be stored, in bytes.
+   * @returns {Promise<PaymentIntent>} Intent details including amount, contract address, and expiry.
+   */
+  createPaymentIntent: (sizeBytes: number) => Promise<PaymentIntent>
+
+  /**
+   * Notifies Auto Drive that an on-chain transaction has been submitted for a payment intent.
+   *
+   * Auto Drive will watch the transaction and automatically apply storage credits
+   * to your account once confirmed on-chain.
+   *
+   * @param intentId - The intent ID from `createPaymentIntent`.
+   * @param txHash   - The on-chain transaction hash.
+   */
+  watchPaymentTransaction: (intentId: string, txHash: string) => Promise<void>
+
+  /**
+   * Returns the current status of a payment intent.
+   *
+   * Possible statuses: PENDING | CONFIRMED | COMPLETED | EXPIRED | FAILED | OVER_CAP
+   *
+   * @param intentId - The intent ID from `createPaymentIntent`.
+   */
+  getPaymentIntentStatus: (intentId: string) => Promise<{ id: string; status: PaymentIntentStatus }>
+
+  /**
+   * Polls a payment intent until it reaches a terminal state.
+   *
+   * Returns the terminal status: COMPLETED | EXPIRED | FAILED | OVER_CAP.
+   * Throws if the timeout is exceeded before a terminal state is reached.
+   *
+   * @param intentId - The intent ID from `createPaymentIntent`.
+   * @param options  - Optional poll interval and timeout (defaults: 3 s / 5 min).
+   */
+  waitForPaymentCompletion: (
+    intentId: string,
+    options?: PollOptions,
+  ) => Promise<PaymentIntentTerminalStatus>
+
   /**
    * Publishes an object by sending a request to the server.
    *

--- a/packages/auto-drive/src/api/types.ts
+++ b/packages/auto-drive/src/api/types.ts
@@ -192,7 +192,9 @@ export interface AutoDriveApi extends AutoDriveApiHandler {
    * `intent.ai3AmountWei` to the Credits Receiver contract via `payIntent(intent.intentId)`,
    * then call `watchPaymentTransaction` to notify Auto Drive.
    *
-   * @param sizeBytes - The size of the content to be stored, in bytes.
+   * @param sizeBytes - Upload size in bytes. Used **locally** to compute
+   *   `ai3AmountWei = shannonsPerByte × sizeBytes`. It is not sent to the server —
+   *   the POST `/intents` endpoint accepts no request body.
    * @returns {Promise<PaymentIntent>} Intent details including amount, contract address, and expiry.
    */
   createPaymentIntent: (sizeBytes: number) => Promise<PaymentIntent>

--- a/packages/auto-drive/src/api/types.ts
+++ b/packages/auto-drive/src/api/types.ts
@@ -8,6 +8,7 @@ import {
   PaymentIntentStatus,
   PaymentIntentTerminalStatus,
   PollOptions,
+  StoragePrice,
 } from './models/payment'
 import { SubscriptionInfo, UserInfo } from './models/user'
 import { AutoDriveNetwork } from './networks'
@@ -174,6 +175,16 @@ export interface AutoDriveApi extends AutoDriveApiHandler {
   // ---------------------------------------------------------------------------
   // Pay with AI3 — credit purchase via on-chain payment intent
   // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the current live storage price without creating a price-locked intent.
+   *
+   * This is a public endpoint — no API key required.
+   * Use it to display a cost estimate to users before they commit to a payment.
+   *
+   * @returns {Promise<StoragePrice>} Current price per byte and a pre-computed AI3/GB display value.
+   */
+  getStoragePrice: () => Promise<StoragePrice>
 
   /**
    * Fetches the EVM chain ID, contract address, and ABI for the Credits Receiver contract.

--- a/packages/auto-drive/src/api/wrappers.ts
+++ b/packages/auto-drive/src/api/wrappers.ts
@@ -10,6 +10,7 @@ import mime from 'mime-types'
 import { progressToPercentage } from '../utils/misc'
 import { publicDownloadUrl } from './calls/download'
 import { apiCalls } from './calls/index'
+import { PollOptions } from './models/payment'
 import { ObjectSummary, Scope } from './models'
 import { DownloadStatus } from './models/asyncDownloads'
 import { PaginatedResult } from './models/common'
@@ -320,6 +321,20 @@ export const createApiInterface = (api: AutoDriveApiHandler): AutoDriveApi => {
     return me.subscription
   }
 
+  const getPaymentContractInfo = () => apiCalls.getPaymentContractInfo(api)
+
+  const createPaymentIntent = (sizeBytes: number) =>
+    apiCalls.createPaymentIntent(api, sizeBytes)
+
+  const watchPaymentTransaction = (intentId: string, txHash: string) =>
+    apiCalls.watchPaymentTransaction(api, intentId, txHash)
+
+  const getPaymentIntentStatus = (intentId: string) =>
+    apiCalls.getPaymentIntentStatus(api, intentId)
+
+  const waitForPaymentCompletion = (intentId: string, options?: PollOptions) =>
+    apiCalls.waitForPaymentCompletion(api, intentId, options)
+
   const publishObject = async (cid: string): Promise<string> => {
     const result = await apiCalls.publishObject(api, { cid })
 
@@ -372,6 +387,11 @@ export const createApiInterface = (api: AutoDriveApiHandler): AutoDriveApi => {
     downloadFile,
     getPendingCredits,
     getSubscriptionInfo,
+    getPaymentContractInfo,
+    createPaymentIntent,
+    watchPaymentTransaction,
+    getPaymentIntentStatus,
+    waitForPaymentCompletion,
     publishObject,
     getMyFiles,
     searchByNameOrCIDInMyFiles,

--- a/packages/auto-drive/src/api/wrappers.ts
+++ b/packages/auto-drive/src/api/wrappers.ts
@@ -321,6 +321,8 @@ export const createApiInterface = (api: AutoDriveApiHandler): AutoDriveApi => {
     return me.subscription
   }
 
+  const getStoragePrice = () => apiCalls.getStoragePrice(api)
+
   const getPaymentContractInfo = () => apiCalls.getPaymentContractInfo(api)
 
   const createPaymentIntent = (sizeBytes: number) =>
@@ -387,6 +389,7 @@ export const createApiInterface = (api: AutoDriveApiHandler): AutoDriveApi => {
     downloadFile,
     getPendingCredits,
     getSubscriptionInfo,
+    getStoragePrice,
     getPaymentContractInfo,
     createPaymentIntent,
     watchPaymentTransaction,


### PR DESCRIPTION
## Summary

- Adds five new methods to `AutoDriveApi` covering the complete credit purchase flow via on-chain payment intents: `getPaymentContractInfo`, `createPaymentIntent`, `watchPaymentTransaction`, `getPaymentIntentStatus`, `waitForPaymentCompletion`
- Adds supporting types: `PaymentContractInfo`, `PaymentIntent`, `PaymentIntentStatus`, `PaymentIntentTerminalStatus`, `PollOptions`
- Documents the full four-step Pay with AI3 flow in the `auto-drive` README with server-side and client-side examples
- Purely additive — zero changes to existing code, no breaking changes

## The four-step flow

```
1. createPaymentIntent(api, sizeBytes)   - locks price, returns amount + contract details
2. send ai3AmountWei to contractAddress  - payIntent(intentId) on-chain (caller's wallet code)
3. watchPaymentTransaction(api, id, tx)  - notifies Auto Drive of the tx hash
4. waitForPaymentCompletion(api, id)     - polls until COMPLETED (credits applied)
```

`getPaymentContractInfo` is a public endpoint (no API key required) and is called internally by `createPaymentIntent`. It is also exported for callers who need the contract details independently (e.g. to pre-fetch the ABI for a client-side wallet).

## Notes

- The pre-existing ESLint config references `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` which are not declared in root `package.json` devDependencies — linting fails on an unmodified checkout. This is unrelated to this PR but may surface in CI.
- `tsc --noEmit` and `yarn build` both pass cleanly.

Generated with [Claude Code](https://claude.com/claude-code)
