### PR TITLE
fix: detectTxSuccess always returns false (forEach → some)

### DIFF
--- a/packages/auto-utils/src/utils/detectTxSuccess.ts
+++ b/packages/auto-utils/src/utils/detectTxSuccess.ts
@@ -34,10 +34,7 @@ import { expectSuccessfulTxEvent } from './events'
  *   }
  * })
  */
-export const detectTxSuccess = (events: EventRecord[]): boolean => {
-  events.forEach(({ event: { method, section } }) => {
-    if (expectSuccessfulTxEvent.indexOf(`${section}.${method}`) > -1) return true
-  })
-
-  return false
-}
+export const detectTxSuccess = (events: EventRecord[]): boolean =>
+  events.some(({ event: { method, section } }) =>
+    expectSuccessfulTxEvent.indexOf(`${section}.${method}`) > -1,
+  )


### PR DESCRIPTION
## Summary

`detectTxSuccess` in `@autonomys/auto-utils` always returned `false` because a `return true` inside `Array.forEach()` returns from the arrow-function callback, not from `detectTxSuccess` itself. The function always fell through to `return false`.

Replace `forEach` with `some`, which correctly short-circuits and propagates the boolean result.

## Root Cause

```ts
// Before (broken)
export const detectTxSuccess = (events: EventRecord[]): boolean => {
  events.forEach(({ event: { method, section } }) => {
    if (expectSuccessfulTxEvent.indexOf(`${section}.${method}`) > -1) return true  // ← returns from callback, not detectTxSuccess
  })
  return false  // ← always reached
}

// After (fixed)
export const detectTxSuccess = (events: EventRecord[]): boolean =>
  events.some(({ event: { method, section } }) =>
    expectSuccessfulTxEvent.indexOf(`${section}.${method}`) > -1,
  )
```

## Impact

Every consumer of `signAndSendTx` that checks `result.success` always saw `false`, even for confirmed transactions. The `result.success` field is now correctly `true` when a success event (e.g. `system.ExtrinsicSuccess`) is present.

Closes #516

Made with [Cursor](https://cursor.com)