### PR TITLE
feat(file-server): add S3 ListObjectsV2 and ETag helpers

### DIFF
--- a/packages/utility/file-server/src/index.ts
+++ b/packages/utility/file-server/src/index.ts
@@ -5,3 +5,4 @@ export const version = packageJson.version
 export * from './caching/index.js'
 export * from './http/index.js'
 export * from './models.js'
+export * from './s3/index.js'

--- a/packages/utility/file-server/src/s3/__tests__/etag.test.ts
+++ b/packages/utility/file-server/src/s3/__tests__/etag.test.ts
@@ -1,0 +1,52 @@
+import { createHash } from 'crypto'
+import { formatETag, md5Hex, multipartETag } from '../etag.js'
+
+describe('md5Hex', () => {
+  it('computes the MD5 of an empty buffer', () => {
+    expect(md5Hex(Buffer.from(''))).toBe('d41d8cd98f00b204e9800998ecf8427e')
+  })
+
+  it('computes the MD5 of a known input', () => {
+    // echo -n "hello" | md5
+    expect(md5Hex(Buffer.from('hello'))).toBe('5d41402abc4b2a76b9719d911017c592')
+  })
+})
+
+describe('formatETag', () => {
+  it('wraps a hex digest in double quotes', () => {
+    expect(formatETag('5d41402abc4b2a76b9719d911017c592')).toBe(
+      '"5d41402abc4b2a76b9719d911017c592"',
+    )
+  })
+})
+
+describe('multipartETag', () => {
+  it('computes the AWS composite ETag from quoted part ETags', () => {
+    const part1 = md5Hex(Buffer.from('part-one'))
+    const part2 = md5Hex(Buffer.from('part-two'))
+
+    const expectedComposite = createHash('md5')
+      .update(Buffer.concat([Buffer.from(part1, 'hex'), Buffer.from(part2, 'hex')]))
+      .digest('hex')
+
+    expect(multipartETag([formatETag(part1), formatETag(part2)])).toBe(
+      `"${expectedComposite}-2"`,
+    )
+  })
+
+  it('accepts unquoted part ETags as well', () => {
+    const part1 = md5Hex(Buffer.from('a'))
+    const quoted = multipartETag([formatETag(part1)])
+    const unquoted = multipartETag([part1])
+    expect(unquoted).toBe(quoted)
+  })
+
+  it('appends the part count after a hyphen', () => {
+    const parts = [
+      md5Hex(Buffer.from('1')),
+      md5Hex(Buffer.from('2')),
+      md5Hex(Buffer.from('3')),
+    ]
+    expect(multipartETag(parts)).toMatch(/^"[0-9a-f]{32}-3"$/)
+  })
+})

--- a/packages/utility/file-server/src/s3/__tests__/listObjects.test.ts
+++ b/packages/utility/file-server/src/s3/__tests__/listObjects.test.ts
@@ -52,6 +52,12 @@ describe('buildListResult', () => {
     expect(result.isTruncated).toBe(false)
   })
 
+  it('folds correctly with a multi-character delimiter', () => {
+    const result = buildListResult(rows('a::1', 'a::2', 'b::1', 'c'), '', '::', 10)
+    expect(result.objects.map((o) => o.key)).toEqual(['c'])
+    expect(result.commonPrefixes).toEqual(['a::', 'b::'])
+  })
+
   it('respects the prefix when computing folded prefixes', () => {
     const result = buildListResult(rows('docs/a/1', 'docs/a/2', 'docs/b'), 'docs/', '/', 10)
     expect(result.objects.map((o) => o.key)).toEqual(['docs/b'])
@@ -125,6 +131,15 @@ describe('finalizeListObjects', () => {
     expect(result.isTruncated).toBe(true)
     expect(result.nextContinuationToken).toBe('a/￿')
     expect(result.commonPrefixes).toEqual(['a/'])
+  })
+
+  it('builds the sentinel token with the full multi-character delimiter', () => {
+    const p = params({ delimiter: '::', maxKeys: 10 })
+    const fetched = rows('a::1', 'a::2', 'a::3')
+    const result = finalizeListObjects(p, fetched, fetched.length)
+    expect(result.isTruncated).toBe(true)
+    expect(result.nextContinuationToken).toBe('a::￿')
+    expect(result.commonPrefixes).toEqual(['a::'])
   })
 
   it('uses the last key as the token when the override fires without a delimiter', () => {

--- a/packages/utility/file-server/src/s3/__tests__/listObjects.test.ts
+++ b/packages/utility/file-server/src/s3/__tests__/listObjects.test.ts
@@ -74,6 +74,16 @@ describe('buildListResult', () => {
     expect(result.isTruncated).toBe(false)
   })
 
+  it('does not crash and returns no entries when maxKeys is 0', () => {
+    // MaxKeys=0 is a valid S3 existence probe. The loop breaks before scanning
+    // anything, so there is no prior key to build a continuation token from.
+    const result = buildListResult(rows('a', 'b', 'c'), '', null, 0)
+    expect(result.objects).toEqual([])
+    expect(result.commonPrefixes).toEqual([])
+    expect(result.isTruncated).toBe(true)
+    expect(result.nextContinuationToken).toBeNull()
+  })
+
   it('handles an empty input', () => {
     const result = buildListResult([], '', '/', 10)
     expect(result.objects).toEqual([])

--- a/packages/utility/file-server/src/s3/__tests__/listObjects.test.ts
+++ b/packages/utility/file-server/src/s3/__tests__/listObjects.test.ts
@@ -1,0 +1,145 @@
+import {
+  buildListResult,
+  computeListObjectsDbLimit,
+  finalizeListObjects,
+  ListObjectsParams,
+  S3ObjectListing,
+} from '../listObjects.js'
+
+const obj = (key: string): S3ObjectListing => ({
+  key,
+  cid: `cid-${key}`,
+  size: 0n,
+  lastModified: new Date(0),
+})
+
+const rows = (...keys: string[]): S3ObjectListing[] => keys.map(obj)
+
+describe('computeListObjectsDbLimit', () => {
+  it('fetches maxKeys + 1 when there is no delimiter', () => {
+    expect(computeListObjectsDbLimit(100, null)).toBe(101)
+  })
+
+  it('over-fetches by 10x + 100 when a delimiter is set', () => {
+    expect(computeListObjectsDbLimit(100, '/')).toBe(1100)
+  })
+
+  it('clamps the delimiter over-fetch at 10,000', () => {
+    expect(computeListObjectsDbLimit(100_000, '/')).toBe(10_000)
+  })
+})
+
+describe('buildListResult', () => {
+  it('returns all objects when under maxKeys and no delimiter', () => {
+    const result = buildListResult(rows('a', 'b', 'c'), '', null, 10)
+    expect(result.objects.map((o) => o.key)).toEqual(['a', 'b', 'c'])
+    expect(result.commonPrefixes).toEqual([])
+    expect(result.isTruncated).toBe(false)
+    expect(result.nextContinuationToken).toBeNull()
+  })
+
+  it('truncates and sets the continuation token when over maxKeys', () => {
+    const result = buildListResult(rows('a', 'b', 'c', 'd'), '', null, 2)
+    expect(result.objects.map((o) => o.key)).toEqual(['a', 'b'])
+    expect(result.isTruncated).toBe(true)
+    expect(result.nextContinuationToken).toBe('b')
+  })
+
+  it('folds keys containing the delimiter into common prefixes', () => {
+    const result = buildListResult(rows('a/1', 'a/2', 'b/1', 'c'), '', '/', 10)
+    expect(result.objects.map((o) => o.key)).toEqual(['c'])
+    expect(result.commonPrefixes).toEqual(['a/', 'b/'])
+    expect(result.isTruncated).toBe(false)
+  })
+
+  it('respects the prefix when computing folded prefixes', () => {
+    const result = buildListResult(rows('docs/a/1', 'docs/a/2', 'docs/b'), 'docs/', '/', 10)
+    expect(result.objects.map((o) => o.key)).toEqual(['docs/b'])
+    expect(result.commonPrefixes).toEqual(['docs/a/'])
+  })
+
+  it('counts objects and common prefixes together against maxKeys', () => {
+    const result = buildListResult(rows('a/1', 'b/1', 'c/1'), '', '/', 2)
+    expect(result.commonPrefixes).toEqual(['a/', 'b/'])
+    expect(result.objects).toEqual([])
+    expect(result.isTruncated).toBe(true)
+    // Token falls before the 'c/' group so the next page re-processes it.
+    expect(result.nextContinuationToken).toBe('b/1')
+  })
+
+  it('does not double-count an already-seen common prefix against maxKeys', () => {
+    const result = buildListResult(rows('a/1', 'a/2', 'a/3', 'b'), '', '/', 2)
+    expect(result.commonPrefixes).toEqual(['a/'])
+    expect(result.objects.map((o) => o.key)).toEqual(['b'])
+    expect(result.isTruncated).toBe(false)
+  })
+
+  it('handles an empty input', () => {
+    const result = buildListResult([], '', '/', 10)
+    expect(result.objects).toEqual([])
+    expect(result.commonPrefixes).toEqual([])
+    expect(result.isTruncated).toBe(false)
+    expect(result.nextContinuationToken).toBeNull()
+  })
+})
+
+describe('finalizeListObjects', () => {
+  const params = (overrides: Partial<ListObjectsParams> = {}): ListObjectsParams => ({
+    bucket: 'my-bucket',
+    prefix: '',
+    delimiter: '/',
+    maxKeys: 10,
+    continuationToken: null,
+    ...overrides,
+  })
+
+  it('wraps buildListResult with bucket name, prefix and maxKeys', () => {
+    const p = params({ delimiter: null, maxKeys: 5 })
+    const dbLimit = computeListObjectsDbLimit(p.maxKeys, p.delimiter)
+    const result = finalizeListObjects(p, rows('a', 'b'), dbLimit)
+    expect(result.name).toBe('my-bucket')
+    expect(result.prefix).toBe('')
+    expect(result.maxKeys).toBe(5)
+    expect(result.objects.map((o) => o.key)).toEqual(['a', 'b'])
+    expect(result.isTruncated).toBe(false)
+  })
+
+  it('forces truncation with a sentinel token when a full batch folds entirely into one prefix', () => {
+    // Every fetched row folds into 'a/' and none break the maxKeys cap, so
+    // buildListResult alone would wrongly report isTruncated=false. The full
+    // batch (fetchedRows.length === dbLimit) signals there may be more.
+    const p = params({ maxKeys: 10 })
+    const fetched = rows('a/1', 'a/2', 'a/3')
+    const dbLimit = fetched.length
+    const result = finalizeListObjects(p, fetched, dbLimit)
+    expect(result.isTruncated).toBe(true)
+    expect(result.nextContinuationToken).toBe('a/￿')
+    expect(result.commonPrefixes).toEqual(['a/'])
+  })
+
+  it('uses the last key as the token when the override fires without a delimiter', () => {
+    const p = params({ delimiter: null, maxKeys: 10 })
+    const fetched = rows('x', 'y')
+    const result = finalizeListObjects(p, fetched, fetched.length)
+    expect(result.isTruncated).toBe(true)
+    expect(result.nextContinuationToken).toBe('y')
+  })
+
+  it('uses the last key as the token when the last key does not fold', () => {
+    const p = params({ maxKeys: 10 })
+    // 'z' has no delimiter after the prefix, so it is not part of a prefix group.
+    const fetched = rows('a/1', 'z')
+    const result = finalizeListObjects(p, fetched, fetched.length)
+    expect(result.isTruncated).toBe(true)
+    expect(result.nextContinuationToken).toBe('z')
+  })
+
+  it('does not override when the batch was not full', () => {
+    const p = params({ maxKeys: 10 })
+    const fetched = rows('a/1', 'a/2')
+    // dbLimit larger than fetched → storage returned everything, no more pages.
+    const result = finalizeListObjects(p, fetched, 100)
+    expect(result.isTruncated).toBe(false)
+    expect(result.nextContinuationToken).toBeNull()
+  })
+})

--- a/packages/utility/file-server/src/s3/etag.ts
+++ b/packages/utility/file-server/src/s3/etag.ts
@@ -1,0 +1,21 @@
+import { createHash } from 'crypto'
+
+// Compute the hex MD5 digest of a buffer.
+export const md5Hex = (data: Buffer): string => createHash('md5').update(data).digest('hex')
+
+// Format a raw hex MD5 as a quoted S3 ETag: `"<hex>"`.
+export const formatETag = (hex: string): string => `"${hex}"`
+
+/**
+ * Compute the S3 composite ETag for a multipart upload.
+ *
+ * AWS format: MD5 of the binary concatenation of each part's raw MD5 bytes,
+ * followed by a hyphen and the part count. e.g. `"abc123...-3"`.
+ *
+ * Part ETags are expected in quoted hex format: `"d41d8cd98f00b204e9800998ecf8427e"`.
+ */
+export const multipartETag = (partETags: string[]): string => {
+  const partMd5Buffers = partETags.map((tag) => Buffer.from(tag.replace(/"/g, ''), 'hex'))
+  const composite = md5Hex(Buffer.concat(partMd5Buffers))
+  return `"${composite}-${partETags.length}"`
+}

--- a/packages/utility/file-server/src/s3/index.ts
+++ b/packages/utility/file-server/src/s3/index.ts
@@ -1,0 +1,2 @@
+export * from './etag.js'
+export * from './listObjects.js'

--- a/packages/utility/file-server/src/s3/listObjects.ts
+++ b/packages/utility/file-server/src/s3/listObjects.ts
@@ -107,7 +107,10 @@ export const buildListResult = (
   }
 
   const isTruncated = scanIdx < sortedObjects.length
-  const nextContinuationToken = isTruncated ? sortedObjects[scanIdx - 1].key : null
+  // scanIdx === 0 means nothing was scanned (e.g. maxKeys <= 0, a valid S3
+  // existence probe). There is no prior key to resume from, so omit the token
+  // rather than indexing sortedObjects[-1].
+  const nextContinuationToken = isTruncated && scanIdx > 0 ? sortedObjects[scanIdx - 1].key : null
 
   return {
     objects,

--- a/packages/utility/file-server/src/s3/listObjects.ts
+++ b/packages/utility/file-server/src/s3/listObjects.ts
@@ -1,0 +1,183 @@
+// Pure ListObjectsV2 logic: delimiter folding, maxKeys pagination, and
+// continuation-token placement. The only piece left to the caller is the
+// actual storage query that produces the sorted rows fed into finalizeListObjects.
+
+/** A single object entry returned by ListObjectsV2. */
+export interface S3ObjectListing {
+  key: string
+  cid: string
+  /** Object size in bytes; 0 when not yet indexed. */
+  size: bigint
+  lastModified: Date
+}
+
+export interface ListObjectsParams {
+  bucket: string
+  /** Key prefix to filter results (default: empty string = all keys). */
+  prefix: string
+  /** If set, fold keys at this character into CommonPrefixes (rclone uses '/'). */
+  delimiter: string | null
+  /** Maximum number of logical entries (objects + common prefixes) to return. */
+  maxKeys: number
+  /** Opaque token returned by a previous truncated response. */
+  continuationToken: string | null
+}
+
+export interface ListObjectsResult {
+  name: string
+  prefix: string
+  maxKeys: number
+  isTruncated: boolean
+  nextContinuationToken: string | null
+  objects: S3ObjectListing[]
+  commonPrefixes: string[]
+}
+
+/**
+ * How many raw rows to fetch from storage for a given page request.
+ *
+ * Without a delimiter every row is a distinct logical entry, so we only need
+ * maxKeys + 1 rows (the extra row lets buildListResult detect truncation
+ * without fetching the entire table). With a delimiter, multiple rows can fold
+ * into a single CommonPrefix, so we over-fetch by a factor of 10 to handle
+ * large prefix groups while still keeping memory use bounded.
+ */
+export const computeListObjectsDbLimit = (maxKeys: number, delimiter: string | null): number =>
+  delimiter ? Math.min(maxKeys * 10 + 100, 10_000) : maxKeys + 1
+
+/**
+ * Apply delimiter folding and maxKeys pagination to a sorted list of all
+ * matching objects.
+ *
+ * Keys that contain `delimiter` after the prefix are folded into
+ * CommonPrefixes entries. Pagination tracks the last raw key scanned so that
+ * the continuation token restores the exact position on the next call.
+ *
+ * When maxKeys entries are accumulated and the next entry would be a new
+ * CommonPrefix, we stop before adding it. The continuation token is set to the
+ * last key already scanned, which falls before the new prefix group, so the
+ * next page re-processes that group from the beginning.
+ */
+export const buildListResult = (
+  sortedObjects: S3ObjectListing[],
+  prefix: string,
+  delimiter: string | null,
+  maxKeys: number,
+): Pick<
+  ListObjectsResult,
+  'objects' | 'commonPrefixes' | 'isTruncated' | 'nextContinuationToken'
+> => {
+  const objects: S3ObjectListing[] = []
+  const commonPrefixSet = new Set<string>()
+  let scanIdx = 0
+
+  while (scanIdx < sortedObjects.length) {
+    const { key } = sortedObjects[scanIdx]
+
+    // Check whether this key folds into a common prefix.
+    let foldedPrefix: string | null = null
+    if (delimiter) {
+      const afterPrefix = key.slice(prefix.length)
+      const delimIdx = afterPrefix.indexOf(delimiter)
+      if (delimIdx >= 0) {
+        foldedPrefix = prefix + afterPrefix.slice(0, delimIdx + 1)
+      }
+    }
+
+    if (foldedPrefix !== null) {
+      if (!commonPrefixSet.has(foldedPrefix)) {
+        // Adding a new common prefix — check if we're already full.
+        if (objects.length + commonPrefixSet.size >= maxKeys) {
+          // Stop here; the continuation token will fall before this prefix
+          // group so the next page re-processes it from the start.
+          break
+        }
+        commonPrefixSet.add(foldedPrefix)
+      }
+      scanIdx++
+      continue
+    }
+
+    // Regular object — check capacity before adding.
+    if (objects.length + commonPrefixSet.size >= maxKeys) {
+      break
+    }
+    objects.push(sortedObjects[scanIdx])
+    scanIdx++
+  }
+
+  const isTruncated = scanIdx < sortedObjects.length
+  const nextContinuationToken = isTruncated ? sortedObjects[scanIdx - 1].key : null
+
+  return {
+    objects,
+    commonPrefixes: [...commonPrefixSet].sort(),
+    isTruncated,
+    nextContinuationToken,
+  }
+}
+
+/**
+ * Turn the rows fetched from storage into a complete ListObjectsV2 result.
+ *
+ * `fetchedRows` must be sorted by key ascending and fetched with the limit
+ * returned by {@link computeListObjectsDbLimit}. `dbLimit` is that same limit —
+ * it's needed to detect the case where storage returned a full batch and rows
+ * beyond the limit were never seen by {@link buildListResult}.
+ */
+export const finalizeListObjects = (
+  params: ListObjectsParams,
+  fetchedRows: S3ObjectListing[],
+  dbLimit: number,
+): ListObjectsResult => {
+  const { bucket, prefix, delimiter, maxKeys } = params
+
+  const listResult = buildListResult(fetchedRows, prefix, delimiter, maxKeys)
+  const { objects, commonPrefixes } = listResult
+  let { isTruncated, nextContinuationToken } = listResult
+
+  // If storage returned a full batch (fetchedRows.length === dbLimit) there may
+  // be rows beyond the LIMIT that buildListResult never saw. This happens when
+  // every fetched row folds into CommonPrefixes and none break the maxKeys cap —
+  // buildListResult then sees scanIdx === sortedObjects.length and concludes
+  // isTruncated = false. Override to be conservative: one extra empty page is
+  // harmless, but silently dropping data is not.
+  if (!isTruncated && fetchedRows.length === dbLimit) {
+    isTruncated = true
+    const lastKey = fetchedRows[fetchedRows.length - 1].key
+
+    // If the last scanned key folded into a CommonPrefix, the naive choice
+    // `lastKey` would land *inside* a virtual directory we've already
+    // represented in commonPrefixes. The next page's `key > token` query would
+    // then return the remaining keys in that directory, which would re-fold
+    // into — and re-emit — the same CommonPrefix entry.
+    //
+    // Advance the token past every key that could possibly fold into that
+    // prefix by appending a high-sort sentinel. `￿` (encoded as
+    // 0xEF 0xBF 0xBF in UTF-8) sorts after every realistic S3 key character,
+    // so `key > token` skips the rest of the directory and resumes at the
+    // first key that falls outside it.
+    if (delimiter) {
+      const afterPrefix = lastKey.slice(prefix.length)
+      const delimIdx = afterPrefix.indexOf(delimiter)
+      if (delimIdx >= 0) {
+        const lastFoldedPrefix = prefix + afterPrefix.slice(0, delimIdx + 1)
+        nextContinuationToken = lastFoldedPrefix + '￿'
+      } else {
+        nextContinuationToken = lastKey
+      }
+    } else {
+      nextContinuationToken = lastKey
+    }
+  }
+
+  return {
+    name: bucket,
+    prefix,
+    maxKeys,
+    isTruncated,
+    nextContinuationToken,
+    objects,
+    commonPrefixes,
+  }
+}

--- a/packages/utility/file-server/src/s3/listObjects.ts
+++ b/packages/utility/file-server/src/s3/listObjects.ts
@@ -80,7 +80,7 @@ export const buildListResult = (
       const afterPrefix = key.slice(prefix.length)
       const delimIdx = afterPrefix.indexOf(delimiter)
       if (delimIdx >= 0) {
-        foldedPrefix = prefix + afterPrefix.slice(0, delimIdx + 1)
+        foldedPrefix = prefix + afterPrefix.slice(0, delimIdx + delimiter.length)
       }
     }
 
@@ -164,7 +164,7 @@ export const finalizeListObjects = (
       const afterPrefix = lastKey.slice(prefix.length)
       const delimIdx = afterPrefix.indexOf(delimiter)
       if (delimIdx >= 0) {
-        const lastFoldedPrefix = prefix + afterPrefix.slice(0, delimIdx + 1)
+        const lastFoldedPrefix = prefix + afterPrefix.slice(0, delimIdx + delimiter.length)
         nextContinuationToken = lastFoldedPrefix + '￿'
       } else {
         nextContinuationToken = lastKey


### PR DESCRIPTION
## Summary

Extracts the pure, reusable S3 server-side logic out of the Auto Drive backend and into `@autonomys/file-server`, so any S3-compatible layer built on Autonomys storage can reuse it rather than re-implementing it. Suggested in a [review comment on autonomys/auto-drive#696](https://github.com/autonomys/auto-drive/pull/696) and tracked in #534.

Adds a new `s3/` module to `@autonomys/file-server` exporting:

- **`buildListResult(sortedObjects, prefix, delimiter, maxKeys)`** — ListObjectsV2 delimiter folding into CommonPrefixes + maxKeys pagination with correct continuation-token placement.
- **`computeListObjectsDbLimit(maxKeys, delimiter)`** — how many rows to fetch from storage for a page.
- **`finalizeListObjects(params, fetchedRows, dbLimit)`** — wraps `buildListResult` and applies the full-batch truncation override (the `￿` sentinel-token fix from autonomys/auto-drive#711).
- **`md5Hex`, `formatETag`, `multipartETag`** — S3 ETag computation (including AWS composite multipart ETags).
- Types: `S3ObjectListing`, `ListObjectsParams`, `ListObjectsResult`.

## Scope

This is the SDK half of #534. Deliberately **not** moved: the S3 use-case orchestration (`putObject`, `getObject`, multipart, `listBuckets`), the `@auto-drive/s3` DTOs, and the Postgres repository — those have a single consumer (the backend) and are coupled to backend infrastructure, so there's no SDK-user benefit to relocating them. No S3 *client* surface is added to the public SDK API.

A follow-up issue will be raised in `autonomys/auto-drive` to consume these exports once a new `@autonomys/file-server` is published.

## Test plan

- [x] `buildListResult` / `finalizeListObjects` / `computeListObjectsDbLimit` unit tests: pagination, delimiter folding, maxKeys cap across objects + prefixes, continuation-token placement, full-batch truncation override (sentinel token), empty input
- [x] ETag unit tests: known MD5 vectors, quoted format, composite multipart ETag
- [x] `yarn tsc` builds clean; new exports resolve from the built package
- [x] 21 new tests pass (pre-existing `headers.test.ts` workspace-resolution failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #534 