### PR TITLE
fix(file-server): add optional md5 field to S3ObjectListing

### DIFF
--- a/packages/utility/file-server/src/s3/__tests__/listObjects.test.ts
+++ b/packages/utility/file-server/src/s3/__tests__/listObjects.test.ts
@@ -90,6 +90,18 @@ describe('buildListResult', () => {
     expect(result.nextContinuationToken).toBeNull()
   })
 
+  it('preserves the optional md5 field on returned objects', () => {
+    const withMd5: S3ObjectListing = {
+      key: 'a.txt',
+      cid: 'cid-a',
+      size: 0n,
+      lastModified: new Date(0),
+      md5: 'd41d8cd98f00b204e9800998ecf8427e',
+    }
+    const result = buildListResult([withMd5], '', null, 10)
+    expect(result.objects[0].md5).toBe('d41d8cd98f00b204e9800998ecf8427e')
+  })
+
   it('handles an empty input', () => {
     const result = buildListResult([], '', '/', 10)
     expect(result.objects).toEqual([])

--- a/packages/utility/file-server/src/s3/listObjects.ts
+++ b/packages/utility/file-server/src/s3/listObjects.ts
@@ -9,6 +9,13 @@ export interface S3ObjectListing {
   /** Object size in bytes; 0 when not yet indexed. */
   size: bigint
   lastModified: Date
+  /**
+   * MD5 stored at upload, used to populate the per-object ETag in the
+   * ListObjectsV2 response. Optional because not every S3-compatible backend
+   * tracks per-object MD5, and null on backends that do but for objects
+   * uploaded before MD5 support was introduced.
+   */
+  md5?: string | null
 }
 
 export interface ListObjectsParams {


### PR DESCRIPTION
## Summary

Follow-up to #535. The `S3ObjectListing` type was extracted from `auto-drive` before [autonomys/auto-drive#717](https://github.com/autonomys/auto-drive/pull/717) landed there, which added an `md5: string | null` field used to populate the per-object ETag in the ListObjectsV2 XML response (the controller reads `obj.md5` to build the `<ETag>` element). The SDK type as merged is too narrow for the production use case it was built for — auto-drive consumers have to declare a parallel type and cast.

This adds `md5?: string | null` to the SDK's `S3ObjectListing`.

## Why optional, not required

- Not every S3-compatible backend tracks per-object MD5 — keeping it optional preserves the SDK's value as a generic building block.
- It's pure pass-through data: neither `buildListResult` nor `finalizeListObjects` reads or computes it.
- Auto-drive's repository type (`md5: string | null` required) remains assignable to the wider SDK type via structural subtyping, so the planned dedupe in [autonomys/auto-drive#718](https://github.com/autonomys/auto-drive/issues/718) becomes a no-cast import.
- Existing tests that omit `md5` continue to typecheck.

## Test plan

- [x] `yarn tsc` builds clean
- [x] New test: \`buildListResult\` preserves the optional `md5` field unchanged on returned objects
- [x] 73 tests pass across the file-server suite (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)