### PR TITLE
fix(file-server): don't advertise decompressed Content-Length for com…

### DIFF
--- a/packages/utility/file-server/src/http/__tests__/headers.test.ts
+++ b/packages/utility/file-server/src/http/__tests__/headers.test.ts
@@ -386,6 +386,32 @@ describe('handleDownloadResponseHeaders', () => {
       expect(result.shouldDecompressBody).toBe(false)
     })
 
+    it('should NOT advertise the decompressed Content-Length when Content-Encoding is set', () => {
+      // Regression: Content-Length must describe the encoded (compressed) length on the
+      // wire, not the decompressed metadata.size. Since the compressed length is unknown
+      // here, omit Content-Length and rely on chunked transfer encoding.
+      const req = createMockReq({ 'sec-fetch-dest': 'document', 'sec-fetch-mode': 'navigate' })
+      const res = createMockRes()
+      const metadata = { ...defaultMetadata, isCompressed: true }
+
+      handleDownloadResponseHeaders(req as any, res as any, metadata, {})
+
+      expect(res.set).toHaveBeenCalledWith('Content-Encoding', 'deflate')
+      const headers = res._getHeaders()
+      expect(headers['content-length']).toBeUndefined()
+    })
+
+    it('should NOT advertise byte ranges when Content-Encoding is set (compressed body on wire)', () => {
+      const req = createMockReq({ 'sec-fetch-dest': 'document', 'sec-fetch-mode': 'navigate' })
+      const res = createMockRes()
+      const metadata = { ...defaultMetadata, isCompressed: true }
+
+      handleDownloadResponseHeaders(req as any, res as any, metadata, {})
+
+      expect(res.set).toHaveBeenCalledWith('Content-Encoding', 'deflate')
+      expect(res.set).toHaveBeenCalledWith('Accept-Ranges', 'none')
+    })
+
     it('should flag decompression for media types even when encoding skipped', () => {
       const req = createMockReq({ 'sec-fetch-dest': 'video', 'sec-fetch-mode': 'no-cors' })
       const res = createMockRes()
@@ -425,6 +451,22 @@ describe('handleDownloadResponseHeaders', () => {
 
       expect(result.shouldDecompressBody).toBe(true)
       expect(res.set).not.toHaveBeenCalledWith('Content-Encoding', 'deflate')
+    })
+
+    it('should not emit 206/Content-Length/Content-Range for a compressed range request', () => {
+      // Compressed files decompress server-side, so the requested byte range can't be
+      // honored against the decompressed body: we fall back to a full chunked response.
+      const req = createMockReq()
+      const res = createMockRes()
+      const metadata = { ...defaultMetadata, isCompressed: true }
+      const options = { byteRange: [0, 49] as [number, number] }
+
+      handleDownloadResponseHeaders(req as any, res as any, metadata, options)
+
+      expect(res.status).not.toHaveBeenCalledWith(206)
+      expect(res.set).not.toHaveBeenCalledWith('Content-Range', expect.anything())
+      expect(res._getHeaders()['content-length']).toBeUndefined()
+      expect(res.set).toHaveBeenCalledWith('Accept-Ranges', 'none')
     })
   })
 

--- a/packages/utility/file-server/src/http/__tests__/responseBody.test.ts
+++ b/packages/utility/file-server/src/http/__tests__/responseBody.test.ts
@@ -1,0 +1,55 @@
+import { CompressionAlgorithm, compressFile } from '@autonomys/auto-dag-data'
+import { Readable } from 'stream'
+import { deflateSync } from 'zlib'
+import { createResponseBodyTransform } from '../responseBody.js'
+
+const collect = async (stream: Readable): Promise<Buffer> => {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+describe('createResponseBodyTransform', () => {
+  it('inflates the body when shouldDecompressBody is true (Node zlib format)', async () => {
+    const original = Buffer.from('hello compressed world', 'utf8')
+    const compressed = deflateSync(original)
+
+    const transform = createResponseBodyTransform({ shouldDecompressBody: true })
+    Readable.from([compressed]).pipe(transform)
+
+    const result = await collect(transform)
+    expect(result.toString('utf8')).toBe(original.toString('utf8'))
+  })
+
+  it('inflates bodies produced by the actual upload compression (fflate Zlib)', async () => {
+    // The upload path compresses with fflate's `Zlib` (RFC 1950 zlib-wrapped deflate).
+    // This proves createInflate() — not createInflateRaw() — is the correct decoder.
+    const original = Buffer.from('the quick brown fox '.repeat(1000), 'utf8')
+    const compressedChunks: Buffer[] = []
+    for await (const chunk of compressFile(Readable.from([original]), {
+      algorithm: CompressionAlgorithm.ZLIB,
+    })) {
+      compressedChunks.push(Buffer.from(chunk))
+    }
+    const compressed = Buffer.concat(compressedChunks)
+    expect(compressed.length).toBeLessThan(original.length)
+
+    const transform = createResponseBodyTransform({ shouldDecompressBody: true })
+    Readable.from([compressed]).pipe(transform)
+
+    const result = await collect(transform)
+    expect(result.equals(original)).toBe(true)
+  })
+
+  it('passes the body through unchanged when shouldDecompressBody is false', async () => {
+    const original = Buffer.from('raw bytes on the wire', 'utf8')
+
+    const transform = createResponseBodyTransform({ shouldDecompressBody: false })
+    Readable.from([original]).pipe(transform)
+
+    const result = await collect(transform)
+    expect(result.toString('utf8')).toBe(original.toString('utf8'))
+  })
+})

--- a/packages/utility/file-server/src/http/headers.ts
+++ b/packages/utility/file-server/src/http/headers.ts
@@ -83,6 +83,18 @@ const buildDisposition = (req: Request, metadata: DownloadMetadata, filename: st
 }
 
 export type DownloadHeaderResult = {
+  /**
+   * When true, the caller MUST decompress the response body server-side before
+   * writing it to the wire (e.g. by piping through `zlib.createInflate()`).
+   *
+   * In this case no `Content-Encoding` header is set, so clients will NOT
+   * auto-decompress. Shipping the raw (deflate) `FileResponse` body without
+   * inflating it sends compressed bytes labeled with a decompressed
+   * `Content-Type`, corrupting the response (broken images, failed
+   * `JSON.parse`, content-decoding errors).
+   *
+   * Prefer {@link createResponseBodyTransform} so this can't be forgotten.
+   */
   shouldDecompressBody: boolean
 }
 
@@ -117,20 +129,32 @@ export const handleDownloadResponseHeaders = (
     const canUseBrowserDecompression =
       compressedButNotEncrypted && shouldHandleEncoding && !rawMode && !byteRange && !isMediaType
 
+    // When true, the compressed (deflate) bytes are streamed verbatim on the wire
+    // and the browser is expected to auto-decompress via Content-Encoding.
+    let bodyIsCompressedOnWire = false
     if (canUseBrowserDecompression) {
       res.set('Content-Encoding', 'deflate')
+      bodyIsCompressedOnWire = true
     } else if (compressedButNotEncrypted) {
       shouldDecompressBody = true
     }
 
-    // Set Accept-Ranges once based on final decompression decision
-    // Can't advertise ranges when decompressing (can't seek in stream) or when size unknown
-    const canAdvertiseRanges = !shouldDecompressBody && metadata.size != null
+    // Set Accept-Ranges once based on the final body decision.
+    // Can't advertise ranges when decompressing server-side (can't seek in stream),
+    // when the on-the-wire body is compressed (offsets map to compressed bytes, not
+    // the decompressed size we'd advertise), or when the size is unknown.
+    const canAdvertiseRanges =
+      !shouldDecompressBody && !bodyIsCompressedOnWire && metadata.size != null
     res.set('Accept-Ranges', canAdvertiseRanges ? 'bytes' : 'none')
 
-    if (shouldDecompressBody) {
-      // When decompressing, we can't know the output size upfront
-      // Don't set Content-Length - this will use chunked transfer encoding
+    if (shouldDecompressBody || bodyIsCompressedOnWire) {
+      // bodyIsCompressedOnWire: the compressed bytes are sent verbatim with
+      //   Content-Encoding: deflate, and the compressed length is not known here, so
+      //   advertising metadata.size (the decompressed size) would mismatch the wire body.
+      // shouldDecompressBody: we inflate server-side and stream the result; rather than
+      //   trusting metadata.size to exactly match the inflated byte count, we stream it.
+      // In both cases, omit Content-Length and rely on chunked transfer encoding so the
+      // advertised length can never disagree with the bytes actually placed on the wire.
     } else if (byteRange && metadata.size != null) {
       // For range requests on non-compressed content
       res.status(206)

--- a/packages/utility/file-server/src/http/index.ts
+++ b/packages/utility/file-server/src/http/index.ts
@@ -1,1 +1,2 @@
 export * from './headers.js'
+export * from './responseBody.js'

--- a/packages/utility/file-server/src/http/responseBody.ts
+++ b/packages/utility/file-server/src/http/responseBody.ts
@@ -1,0 +1,28 @@
+import { PassThrough, Transform } from 'stream'
+import { createInflate } from 'zlib'
+import { DownloadHeaderResult } from './headers.js'
+
+/**
+ * Returns the stream transform that must be applied to a `FileResponse` body
+ * before it is written to the HTTP response, based on the result of
+ * {@link handleDownloadResponseHeaders}.
+ *
+ * This exists to make the `shouldDecompressBody` contract impossible to forget:
+ * when `shouldDecompressBody` is true the caller MUST decompress the (deflate)
+ * body server-side, otherwise it ships raw compressed bytes labeled with a
+ * decompressed Content-Type and no Content-Encoding, corrupting the response.
+ *
+ * Usage:
+ *
+ * ```ts
+ * const result = handleDownloadResponseHeaders(req, res, metadata, options)
+ * pipeline(file.data, createResponseBodyTransform(result), res, (err) => { ... })
+ * ```
+ *
+ * - When `shouldDecompressBody` is true, returns a `zlib` inflate transform.
+ * - Otherwise returns a pass-through transform (no-op), so callers can always
+ *   pipe through the returned stream unconditionally.
+ */
+export const createResponseBodyTransform = ({
+  shouldDecompressBody,
+}: DownloadHeaderResult): Transform => (shouldDecompressBody ? createInflate() : new PassThrough())


### PR DESCRIPTION
…pressed bodies

Resolves https://github.com/autonomys/auto-sdk/issues/541

handleDownloadResponseHeaders set Content-Length to metadata.size (the decompressed size) even when sending a compressed body — either verbatim with Content-Encoding: deflate (document navigations) or as raw deflate bytes the caller is expected to inflate. The advertised length then did not match the bytes on the wire, so clients truncated or aborted the transfer (failed fetch, broken images, curl content-decoding errors).

- Omit Content-Length (use chunked transfer) whenever the wire body is compressed: server-side decompression or Content-Encoding: deflate.
- Only advertise Accept-Ranges: bytes when the body is not compressed on the wire and the size is known; ranges don't map to a compressed body.
- Add createResponseBodyTransform() so callers can't silently ignore the shouldDecompressBody contract, and document the contract loudly.

Verified createInflate() (zlib-wrapped, RFC 1950) matches the fflate Zlib output produced by the upload path.