### PR TITLE
chore(ci): align workflow Node versions with engines + extend Renovate scope

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,10 @@
       "matchPackageNames": ["/^react/", "/^@react/", "/redux/", "/^@redux/"]
     },
     {
+      "groupName": "node.js",
+      "matchPackageNames": ["node"]
+    },
+    {
       "matchDepTypes": ["peerDependencies"],
       "enabled": false
     }
@@ -45,7 +49,7 @@
     "enabled": true,
     "schedule": ["before 5am on monday"]
   },
-  "includePaths": ["package.json", "**/package.json"],
+  "includePaths": ["package.json", "**/package.json", ".github/workflows/*.yaml"],
   "dependencyDashboard": true,
   "prHourlyLimit": 2,
   "prConcurrentLimit": 10,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,7 +38,7 @@
     },
     {
       "groupName": "node.js",
-      "matchPackageNames": ["node"]
+      "matchPackageNames": ["node", "actions/node-versions"]
     },
     {
       "matchDepTypes": ["peerDependencies"],

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           scope: '@autonomys'
 


### PR DESCRIPTION
## Summary

Two related fixes for an inconsistency spotted while reviewing #606:

1. **Bump CI Node versions to 20** — three workflows still pinned to Node 18 (`build.yaml`, `release.yaml`, `pr-title-check.yaml`), but `package.json` engines say `>=20.8.0` (going to `>=20.20.2` in #606). Build passes anyway because Yarn 4 treats engines as advisory, but the declaration was misleading.

2. **Extend Renovate's `includePaths`** to include `.github/workflows/*.yaml`. The previous config restricted Renovate to `package.json` files only, so workflow Node versions never got tracked. Also adds a `node.js` group rule so future engines + workflow Node bumps land in one PR.

## Why this matters

Without the Renovate config change, this drift would silently recur — the next time engines are bumped, the workflows would fall out of alignment again. With `.github/workflows/*.yaml` in `includePaths` plus the `node.js` grouping rule, Renovate will catch and group these together.

## Changes

| File | Change |
|---|---|
| `.github/workflows/build.yaml` | `node-version: '18'` → `'20'` |
| `.github/workflows/release.yaml` | `node-version: '18'` → `'20'` |
| `.github/workflows/pr-title-check.yaml` | `node-version: '18'` → `'20'` |
| `.github/renovate.json` | Add `.github/workflows/*.yaml` to `includePaths`; add `node.js` packageRule group |
| `.github/workflows/integration-tests.yaml` | Already `'20'` — no change |

## Test plan

- [x] Renovate config is valid JSON
- [x] CI: `Build all packages and run tests` (now on Node 20)
- [x] CI: `Run integration tests with farmerless dev node`
- [x] CI: `validate` (`pr-title-check.yaml` now on Node 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)