### PR TITLE
fix(rpc): narrow Buffer.from input for TS 5.9 overload resolution

### DIFF
--- a/packages/utility/rpc/src/utils/websocket.ts
+++ b/packages/utility/rpc/src/utils/websocket.ts
@@ -3,9 +3,11 @@ import Websocket from 'websocket'
 export const parseData = (message: Websocket.IMessageEvent['data']): string => {
   if (typeof message === 'string') {
     return message
-  } else {
-    return Buffer.from(message).toString('utf8')
   }
+  if (Buffer.isBuffer(message)) {
+    return message.toString('utf8')
+  }
+  return Buffer.from(message).toString('utf8')
 }
 export const parseMessage = (message: Websocket.Message): string => {
   if (message.type === 'utf8') {
@@ -18,9 +20,11 @@ export const parseMessage = (message: Websocket.Message): string => {
 export const encodeMessageData = (message: Websocket.IMessageEvent['data']): Buffer => {
   if (typeof message === 'string') {
     return Buffer.from(message)
-  } else {
-    return Buffer.from(message)
   }
+  if (Buffer.isBuffer(message)) {
+    return message
+  }
+  return Buffer.from(message)
 }
 
 export const encodeMessage = (message: Websocket.IMessageEvent['data']): Websocket.Message => {


### PR DESCRIPTION
## Summary

Prep work for PR #604 (TypeScript 5.8 → 5.9). TS 5.9 tightened overload resolution on `Buffer.from`, so a union argument that doesn't match a single overload exactly is rejected. Two call sites in `packages/utility/rpc/src/utils/websocket.ts` fall into this:

```
src/utils/websocket.ts(7,24): error TS2769: No overload matches this call.
src/utils/websocket.ts(22,24): error TS2769: No overload matches this call.
```

After narrowing out `string`, `message` has type `Buffer | ArrayBuffer`. TS 5.8 was happy; 5.9 wants a single concrete type.

## Fix

Add explicit narrowing with `Buffer.isBuffer` before the `Buffer.from` call. Also avoids an unnecessary copy when the input is already a `Buffer` (small efficiency win).

```ts
// Before
if (typeof message === 'string') return message
return Buffer.from(message).toString('utf8')  // fails on TS 5.9

// After
if (typeof message === 'string') return message
if (Buffer.isBuffer(message)) return message.toString('utf8')
return Buffer.from(message).toString('utf8')  // narrowed to ArrayBuffer
```

## Verified

- [x] `yarn workspace @autonomys/rpc run build` clean under project's TS 5.8.3 (current)
- [x] `tsc --noEmit` clean under TS 5.9.3 (target of #604)
- [x] CI

## Follow-up

After this lands, PR #604 (typescript ^5.9.3) can be rebased and will pass CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)