### PR TITLE
chore(auto-dag-data): drop @peculiar/webcrypto polyfill, use globalThis.crypto

### DIFF
--- a/packages/auto-dag-data/__test__/encryption.spec.ts
+++ b/packages/auto-dag-data/__test__/encryption.spec.ts
@@ -122,4 +122,38 @@ describe('encryption', () => {
       ),
     ).rejects.toThrow('Unsupported encryption algorithm')
   })
+
+  // Regression fixture: ciphertext produced by @peculiar/webcrypto 1.5.0 with
+  // a known plaintext + password. Any WebCrypto implementation (peculiar,
+  // node:crypto.webcrypto, browser) must be able to decrypt this byte-for-byte,
+  // because PBKDF2-SHA256 and AES-GCM are fully specified by the WebCrypto
+  // standard. If this test fails after a crypto-impl swap, encrypted data
+  // produced by previous SDK versions would no longer be readable.
+  it('decrypts a known fixture (cross-implementation regression)', async () => {
+    const FIXTURE_PASSWORD = 'fixture-password-do-not-use-in-real-data'
+    const FIXTURE_PLAINTEXT =
+      'hello world — regression fixture for @peculiar/webcrypto cross-impl compat\n'
+    const FIXTURE_HEX =
+      '983c2e01435eccf98035fd6a24c1614a8a9a6872a879aad0bb3b9aae271674a5' +
+      '2f3c26366cd21c108db66e4efc0692eca0e531f3b17ff0b699c2dfaa6909915b' +
+      'f7f75d461694b846a7c72877aede1e3370bf105740a4a13e12260d75a581f7ee' +
+      '2ea3a56952ebcc49e90ceb6fa90c47fce0f1a1f4a012757ee0fbe64809c4a5e3' +
+      '58a639077eae865a02023a7929'
+
+    const ciphertext = Buffer.from(FIXTURE_HEX, 'hex')
+    const decrypted = decryptFile(
+      (async function* () {
+        yield ciphertext
+      })(),
+      FIXTURE_PASSWORD,
+      { algorithm: EncryptionAlgorithm.AES_256_GCM },
+    )
+
+    let decryptedBuffer = Buffer.alloc(0)
+    for await (const chunk of decrypted) {
+      decryptedBuffer = Buffer.concat([decryptedBuffer, chunk])
+    }
+
+    expect(decryptedBuffer.toString('utf8')).toBe(FIXTURE_PLAINTEXT)
+  })
 })

--- a/packages/auto-dag-data/package.json
+++ b/packages/auto-dag-data/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@autonomys/asynchronous": "^1.6.14",
     "@ipld/dag-pb": "^4.1.7",
-    "@peculiar/webcrypto": "^1.5.0",
     "@webbuf/blake3": "^3.8.0",
     "@webbuf/fixedbuf": "^3.8.0",
     "@webbuf/webbuf": "^3.8.0",

--- a/packages/auto-dag-data/src/encryption/index.ts
+++ b/packages/auto-dag-data/src/encryption/index.ts
@@ -1,11 +1,13 @@
 import { asyncByChunk } from '@autonomys/asynchronous'
-import { Crypto } from '@peculiar/webcrypto'
 import { AwaitIterable } from 'interface-store'
 import { EncryptionAlgorithm, EncryptionOptions } from '../metadata/index.js'
 import type { PickPartial } from '../utils/types.js'
 import { PasswordGenerationOptions } from './types.js'
 
-export const crypto = typeof window === 'undefined' ? new Crypto() : window.crypto
+// Web Crypto is exposed as globalThis.crypto in browsers and in Node 20+.
+// The repo's engines.node floor is 20.20.2 (see root package.json), so the
+// polyfill that @peculiar/webcrypto used to provide is no longer needed.
+export const crypto = globalThis.crypto
 
 export const ENCRYPTING_CHUNK_SIZE = 1024 * 1024
 const IV_SIZE = 16

--- a/packages/auto-dag-data/src/encryption/index.ts
+++ b/packages/auto-dag-data/src/encryption/index.ts
@@ -4,9 +4,6 @@ import { EncryptionAlgorithm, EncryptionOptions } from '../metadata/index.js'
 import type { PickPartial } from '../utils/types.js'
 import { PasswordGenerationOptions } from './types.js'
 
-// Web Crypto is exposed as globalThis.crypto in browsers and in Node 20+.
-// The repo's engines.node floor is 20.20.2 (see root package.json), so the
-// polyfill that @peculiar/webcrypto used to provide is no longer needed.
 export const crypto = globalThis.crypto
 
 export const ENCRYPTING_CHUNK_SIZE = 1024 * 1024

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,7 +82,6 @@ __metadata:
   dependencies:
     "@autonomys/asynchronous": "npm:^1.6.14"
     "@ipld/dag-pb": "npm:^4.1.7"
-    "@peculiar/webcrypto": "npm:^1.5.0"
     "@types/jest": "npm:^29.5.14"
     "@webbuf/blake3": "npm:^3.8.0"
     "@webbuf/fixedbuf": "npm:^3.8.0"
@@ -5836,39 +5835,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@peculiar/asn1-schema@npm:^2.3.13, @peculiar/asn1-schema@npm:^2.3.8":
-  version: 2.3.15
-  resolution: "@peculiar/asn1-schema@npm:2.3.15"
-  dependencies:
-    asn1js: "npm:^3.0.5"
-    pvtsutils: "npm:^1.3.6"
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/0e73e292a17d00a8770825a9504ceaf0994481a39126317ca0ca5d3dc742087f2b71a4d086bb5613bf19ac57f001d42f594683797d43137702db3ee2b42736a0
-  languageName: node
-  linkType: hard
-
-"@peculiar/json-schema@npm:^1.1.12":
-  version: 1.1.12
-  resolution: "@peculiar/json-schema@npm:1.1.12"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  checksum: 10c0/202132c66dcc6b6aca5d0af971c015be2e163da2f7f992910783c5d39c8a7db59b6ec4f4ce419459a1f954b7e1d17b6b253f0e60072c1b3d254079f4eaebc311
-  languageName: node
-  linkType: hard
-
-"@peculiar/webcrypto@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@peculiar/webcrypto@npm:1.5.0"
-  dependencies:
-    "@peculiar/asn1-schema": "npm:^2.3.8"
-    "@peculiar/json-schema": "npm:^1.1.12"
-    pvtsutils: "npm:^1.3.5"
-    tslib: "npm:^2.6.2"
-    webcrypto-core: "npm:^1.8.0"
-  checksum: 10c0/4f6f24b2c52c2155b9c569b6eb1d57954cb5f7bd2764a50cdaed7aea17a6dcf304b75b87b57ba318756ffec8179a07d9a76534aaf77855912b838543e5ff8983
-  languageName: node
-  linkType: hard
-
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -11111,17 +11077,6 @@ __metadata:
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
   checksum: 10c0/c6d5e39fe1f15e4b87677460bd66b66050cd14c772269cee6688824c1410a08ab20254bb6784f9afb75af9144a9f9a7692d49547f4d19d715aeb7c0318f3136d
-  languageName: node
-  linkType: hard
-
-"asn1js@npm:^3.0.5":
-  version: 3.0.6
-  resolution: "asn1js@npm:3.0.6"
-  dependencies:
-    pvtsutils: "npm:^1.3.6"
-    pvutils: "npm:^1.1.3"
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/96d35e65e3df819ad9cc2d91d1150a3041fd84687a62faa73405e72a6b4c655bc2450e779fad524969e14eeac1f69db2559f27ef6d06ddeeddada28f72ad9b89
   languageName: node
   linkType: hard
 
@@ -21391,22 +21346,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pvtsutils@npm:^1.3.5, pvtsutils@npm:^1.3.6":
-  version: 1.3.6
-  resolution: "pvtsutils@npm:1.3.6"
-  dependencies:
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/b1b42646370505ccae536dcffa662303b2c553995211330c8e39dec9ab8c197585d7751c2c5b9ab2f186feda0219d9bb23c34ee1e565573be96450f79d89a13c
-  languageName: node
-  linkType: hard
-
-"pvutils@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "pvutils@npm:1.1.3"
-  checksum: 10c0/23489e6b3c76b6afb6964a20f891d6bef092939f401c78bba186b2bfcdc7a13904a0af0a78f7933346510f8c1228d5ab02d3c80e968fd84d3c76ff98d8ec9aac
-  languageName: node
-  linkType: hard
-
 "qs@npm:6.13.0":
   version: 6.13.0
   resolution: "qs@npm:6.13.0"
@@ -24142,7 +24081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -24929,19 +24868,6 @@ __metadata:
   version: 3.3.3
   resolution: "web-streams-polyfill@npm:3.3.3"
   checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
-  languageName: node
-  linkType: hard
-
-"webcrypto-core@npm:^1.8.0":
-  version: 1.8.1
-  resolution: "webcrypto-core@npm:1.8.1"
-  dependencies:
-    "@peculiar/asn1-schema": "npm:^2.3.13"
-    "@peculiar/json-schema": "npm:^1.1.12"
-    asn1js: "npm:^3.0.5"
-    pvtsutils: "npm:^1.3.5"
-    tslib: "npm:^2.7.0"
-  checksum: 10c0/b85a986b4f73e8505ec5eaafe8e4f1ff02574a3b655793aca91f913d02822c8b79168ad6961eaab86ae00fec00bf780ec4cef7535f64879fb866649bc2a723fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Removes the `@peculiar/webcrypto` polyfill from `auto-dag-data` and uses the platform-native Web Crypto API (`globalThis.crypto`) instead. The polyfill was necessary when the SDK supported Node versions lacking Web Crypto; the engines floor is now `>=20.20.2` (post-#621), and Node 20+ exposes the same standard Web Crypto API at `globalThis.crypto`.

This also resolves the ESM/CJS interop break that has been blocking Renovate PR #610. `@peculiar/webcrypto` 1.7.x shipped as ESM-only, which the project's Jest config (CJS) cannot load. By removing the dep entirely, the problem becomes moot.

## Changes

| File | Change |
|---|---|
| `packages/auto-dag-data/src/encryption/index.ts` | Import + `crypto` source switched from `@peculiar/webcrypto`'s `new Crypto()` to `globalThis.crypto` |
| `packages/auto-dag-data/package.json` | Dropped `@peculiar/webcrypto` from `dependencies` |
| `packages/auto-dag-data/__test__/encryption.spec.ts` | Added cross-implementation regression test |
| `yarn.lock` | Removed `@peculiar/webcrypto` and `webcrypto-core` |

## Cross-implementation safety

The encryption code in `auto-dag-data` passes all crypto parameters explicitly (PBKDF2 with iterations=100000, hash=SHA-256, key length 256; AES-GCM with explicit IV; salt SHA-256 normalised). No implicit defaults means the Web Crypto spec compels any conforming implementation to produce byte-identical output.

To verify this empirically and protect against future impl swaps, this PR also adds a new test:

```ts
it('decrypts a known fixture (cross-implementation regression)', async () => {
  // Ciphertext produced by @peculiar/webcrypto 1.5.0
  // Must decrypt cleanly under any conforming WebCrypto implementation
  const FIXTURE_HEX = '...'
  // ...
  expect(decryptedBuffer.toString('utf8')).toBe(FIXTURE_PLAINTEXT)
})
```

The fixture was generated using the previous `@peculiar/webcrypto` 1.5.0 implementation. **It still decrypts byte-for-byte under `globalThis.crypto`** — empirical proof of cross-impl compatibility. Any future WebCrypto regression that changes PBKDF2 or AES-GCM output will trip this test.

## Verified

- [x] `yarn workspace @autonomys/auto-dag-data run build` clean
- [x] `yarn workspace @autonomys/auto-dag-data run test` — all **65 tests across 8 suites pass**, including the new fixture regression test
- [x] `@peculiar/webcrypto` and `webcrypto-core` no longer appear in `yarn.lock`
- [x] CI

## Effects on the queue

- **Closes (or supersedes) Renovate PR #610** — the polyfill is gone, the bump is moot.
- One fewer transitive dep, one fewer Renovate PR to triage going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)