### PR TITLE
chore(engines): raise root Node floor to 20.20.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "packageManager": "yarn@4.17.0",
   "engines": {
-    "node": ">=18.20.8"
+    "node": ">=20.20.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bump root `engines.node` from `>=18.20.8` to `>=20.20.2`. One line change.

## Why

The current declaration is out of date with reality:

- **CI workflows all pin `node-version: '20'`** (aligned in #621).
- **Three packages already declare `>=20.20.2` directly** — `auto-dag-data`, `auto-drive`, `utility/file-server`.
- **Multiple upstream deps require Node 20+**: `@octokit/rest` v22, recent Next.js security patches, and others being raised by Renovate.
- **Nothing has actually been tested against Node 18** in months — the declared minimum is essentially aspirational.

The mismatch was flagged by Bugbot on PR #649 (`@octokit/rest` v22) — that PR would ship a dev script (`scripts/generate-pr-changelog.js`) that silently fails on Node 18, while the repo still declares Node 18 as supported.

Aligning root to `>=20.20.2` makes the declaration match what the repo already assumes at every operational layer.

## What this unblocks

- **#649** `@octokit/rest` v22 — was blocked on this specific engine mismatch. Merge order: this PR first, then rebase #649.

## What this does NOT unblock

- **#648** commitlint v21 — requires **Node 22+**, still above the new floor.
- **#645** (already closed) babel v8 — also Node 22+.

Both stay closed / held until a separate future decision to move to Node 22.

## Impact

- **CI**: no change (already running Node 20).
- **Developers already on Node 20+**: no change.
- **Developers still on Node 18**: get an install-time engines warning, which is the intended behaviour and reflects reality — the repo isn't tested against Node 18 anymore.

## Test plan

- [x] `yarn install` clean after the change
- [x] CI: `Build all packages and run tests`
- [x] CI: `Run integration tests with farmerless dev node`
- [x] CI: `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)