### PR TITLE
chore(renovate): disable engines updates and remove automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,11 +21,6 @@
       "addLabels": ["optional"]
     },
     {
-      "matchDepTypes": ["minor", "patch", "devDependencies"],
-      "automerge": true,
-      "automergeType": "pr"
-    },
-    {
       "groupName": "Autonomys Auto-SDK",
       "groupSlug": "auto-sdk",
       "automerge": false,
@@ -42,6 +37,10 @@
     },
     {
       "matchDepTypes": ["peerDependencies"],
+      "enabled": false
+    },
+    {
+      "matchDepTypes": ["engines"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
## What

Two changes to `.github/renovate.json`:

1. **Disable `engines`-field updates.** Renovate kept proposing patch-level engine floors (#674 wanted `node >=22.23.1`), and would re-file after every Node patch release. A patch-level floor blocks downstream consumers — Yarn Berry enforces dependency `engines` strictly — while guaranteeing nothing, since no code depends on Node patch versions. Engine floors are a support-policy decision for humans. Workflow `node-version` updates (github-actions manager) are unaffected and continue as before (like #670).

2. **Remove automerge entirely.** The existing rule was broken — `matchDepTypes: ["minor", "patch", "devDependencies"]` mixes update types into a dep-type matcher, so it silently made *all* devDependency updates automerge-eligible, majors included. In practice it never fired because branch protection requires an approving review, which Renovate can't provide. Rather than fix the rule, remove it: given the recent npm supply-chain attacks, dependency merges should stay a deliberate human action. `minimumReleaseAge` (3 days, 7 for majors) remains as the quarantine against compromised releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)